### PR TITLE
feat(vscode-c3-nav): v0.3.0 — markdown navigation, tree view, and bug fixes

### DIFF
--- a/docs/plans/2026-03-10-vscode-c3-doc-navigation-design.md
+++ b/docs/plans/2026-03-10-vscode-c3-doc-navigation-design.md
@@ -1,0 +1,160 @@
+# VSCode C3 Document Navigation Design
+
+**Date:** 2026-03-10
+**Status:** Validated
+
+## Goal
+
+Extend the C3 Architecture Navigator VSCode extension to navigate any document in the `.c3/` folder — not just code-map.yaml. Two new capabilities:
+
+1. **Markdown navigation** — Cross-reference navigation (CodeLens, Hover, Ctrl+Click) inside `.c3/**/*.md` files
+2. **Tree view** — A sidebar panel showing the C3 architecture hierarchy with toggle between hierarchy and flat views
+
+## Architecture Overview
+
+Extend the existing modular structure. The current `DocMap` already indexes all `.c3/*.md` files with frontmatter — it's the foundation for both features.
+
+```
+Existing (unchanged):
+  docMap.ts          — Already indexes IDs, titles, goals, summaries
+  utils.ts           — Already has ID regex, path extraction, frontmatter parsing
+
+New/Extended:
+  codeLensProvider.ts   — Extend to handle .md files (frontmatter + tables)
+  definitionProvider.ts — Extend to handle .md files (all C3 IDs + file paths)
+  hoverProvider.ts      — Extend to handle .md files
+  treeViewProvider.ts   — NEW: TreeDataProvider for sidebar panel
+  extension.ts          — Register new providers and tree view
+```
+
+Key principle: `DocMap` is the single source of truth. Both features read from it, no new data layer needed.
+
+## Markdown Navigation — Provider Changes
+
+### Document selector
+
+All three providers register for `.c3/**/*.md` in addition to existing `.c3/**/*.yaml`.
+
+### CodeLens — Smart placement
+
+- **Frontmatter block** (between `---` delimiters): CodeLens above `parent:`, `uses:`, and `via:` fields. Each referenced ID gets a `-> Title (filename)` lens.
+- **Dependency/Code Reference tables**: CodeLens above rows containing C3 IDs or file paths. Detected by matching markdown table rows (`| ... |`) containing C3 ID patterns or backtick-wrapped file paths.
+- **Body prose**: No CodeLens. Hover + Ctrl+Click only.
+
+Principle: CodeLens for structured references, hover+click for prose references.
+
+### Definition provider
+
+- C3 IDs anywhere in the file -> jump to target `.c3/*.md` document
+- File paths in backticks or quotes (e.g., `` `cli/internal/frontmatter/parse.go` ``) -> open the workspace file
+- Works in frontmatter, tables, and body text uniformly
+
+### Hover provider
+
+- C3 IDs -> same rich card as YAML (id, title, goal, summary)
+- File paths -> same path status display (exists/missing, file/folder)
+- Works everywhere in the document
+
+### Pattern matching additions (`utils.ts`)
+
+- Detect frontmatter block boundaries (`---`)
+- Detect markdown table rows for CodeLens placement decisions
+- Extract file paths from backtick/quote wrappers in markdown context
+
+## Tree View — Structure & Behavior
+
+### Registration
+
+New `TreeDataProvider` registered as a view in the Explorer sidebar. View ID: `c3Navigator`.
+
+### Two toggle modes (toolbar button)
+
+**Hierarchy mode (default):**
+
+```
+c3-0 - C3 Design                          [active]
++-- c3-1 - Go CLI                          [active]
+|   +-- Foundation
+|   |   +-- c3-101 - Frontmatter Parser    [active]
+|   |   +-- c3-102 - Walker                [active]
+|   |   +-- c3-103 - Templates             [active]
+|   |   +-- c3-104 - Wiring               [active]
+|   |   +-- c3-105 - Codemap Lib           [active]
+|   +-- Feature
+|       +-- c3-110 - Init Cmd              [active]
+|       +-- ...
+|       +-- c3-117 - Diff Cmd              [provisioned]
++-- c3-2 - Claude Skill                    [active]
+|   +-- c3-201 - Skill Router              [active]
+|   +-- c3-210 - Operation Refs            [active]
++-- References
+|   +-- ref-frontmatter-docs
+|   +-- ref-embedded-templates
+|   +-- ref-cross-compiled-binary
++-- ADRs
+    +-- adr-00000000 - C3 Adoption
+    +-- adr-20260309 - Add Diff Cmd
+```
+
+**Flat mode:**
+
+```
+Containers (3)
+Components (15)
+References (3)
+ADRs (2)
+```
+
+Each group lists items alphabetically by ID.
+
+### Behavior
+
+- Click any item -> opens the `.md` document
+- Status badges: `[active]` / `[provisioned]` for components, parsed from frontmatter
+- Goal shown as tooltip on hover (not inline, keeps tree clean)
+- Tree auto-refreshes when `DocMap` fires `onDidRebuild` event
+
+## Context Menu Actions
+
+Right-click on any tree item:
+
+| Action | Behavior |
+|--------|----------|
+| Show Dependencies | QuickPick list of components in `uses:` field. Select one -> opens doc. Disabled if empty. |
+| Show Dependents | QuickPick list of components referencing this ID in their `uses:` or `via:` fields. Disabled if none. |
+| Open in Code Map | Opens `code-map.yaml`, scrolls to line containing this component's ID. |
+| Copy ID | Copies ID (e.g., `c3-101`) to clipboard. |
+
+## DocMap Extensions
+
+`DocEntry` interface needs additional fields from frontmatter:
+
+| Field | Purpose |
+|-------|---------|
+| `type` | container / component / ref / adr — for tree grouping |
+| `category` | foundation / feature — for hierarchy sub-grouping |
+| `parent` | parent ID — for hierarchy tree building |
+| `uses` | dependency list — for "Show Dependencies" |
+| `via` | reverse dependency list — for "Show Dependents" |
+| `status` | active / provisioned — for badge display |
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `docMap.ts` | Extend `DocEntry` with `type`, `category`, `parent`, `uses`, `via`, `status` |
+| `utils.ts` | Add frontmatter block detection, markdown table detection, backtick path extraction |
+| `codeLensProvider.ts` | Add `.md` selector, smart placement logic (frontmatter + tables) |
+| `definitionProvider.ts` | Add `.md` selector, backtick path support |
+| `hoverProvider.ts` | Add `.md` selector |
+| `treeViewProvider.ts` | **NEW** — TreeDataProvider with hierarchy/flat toggle, context menu commands |
+| `extension.ts` | Register tree view, context menu commands, toggle command |
+| `package.json` | Declare view container, view, commands, menus |
+
+## Not Building (YAGNI)
+
+- No search/filter bar — VSCode's built-in tree filtering is sufficient
+- No drag-and-drop or editing from tree view — read-only navigation
+- No dependency graph visualization — QuickPick lists are enough
+- No breadcrumb integration — standard VSCode breadcrumbs work fine
+- No custom editor or webview — standard tree view and text editor are sufficient

--- a/docs/plans/2026-03-10-vscode-c3-doc-navigation-impl.md
+++ b/docs/plans/2026-03-10-vscode-c3-doc-navigation-impl.md
@@ -1,0 +1,1500 @@
+# VSCode C3 Document Navigation — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extend the C3 Architecture Navigator VSCode extension to navigate all `.c3/` documents (markdown cross-references + tree view sidebar).
+
+**Architecture:** Extend existing DocMap/providers pattern. DocMap gains new frontmatter fields (type, category, parent, uses, via, status). All three providers gain `.c3/**/*.md` support. New TreeDataProvider for sidebar. No new data layer — DocMap remains single source of truth.
+
+**Tech Stack:** TypeScript, VSCode Extension API, vitest (new, for unit testing pure functions)
+
+**Worktree:** `/Users/cuongtran/Desktop/repo/c3-skill/.worktrees/feat-vscode-c3-doc-nav`
+**Extension root:** `vscode-c3-nav/`
+
+---
+
+## Task 1: Set Up Test Framework
+
+**Files:**
+- Modify: `vscode-c3-nav/package.json`
+- Create: `vscode-c3-nav/src/__tests__/utils.test.ts`
+- Modify: `vscode-c3-nav/tsconfig.json`
+
+**Step 1: Install vitest**
+
+```bash
+cd vscode-c3-nav && npm install -D vitest
+```
+
+**Step 2: Add test script to package.json**
+
+In `package.json`, add to `"scripts"`:
+```json
+"test": "vitest run",
+"test:watch": "vitest"
+```
+
+**Step 3: Create a smoke test**
+
+Create `src/__tests__/utils.test.ts`:
+```typescript
+import { describe, it, expect } from "vitest";
+import { extractIdFromFilename, stripGlobSuffix } from "../utils";
+
+describe("extractIdFromFilename", () => {
+  it("extracts c3 ID from component filename", () => {
+    expect(extractIdFromFilename("c3-113-check-cmd.md")).toBe("c3-113");
+  });
+
+  it("extracts ref ID from ref filename", () => {
+    expect(extractIdFromFilename("ref-frontmatter-docs.md")).toBe("ref-frontmatter-docs");
+  });
+
+  it("returns undefined for README.md", () => {
+    expect(extractIdFromFilename("README.md")).toBeUndefined();
+  });
+});
+
+describe("stripGlobSuffix", () => {
+  it("strips /** suffix", () => {
+    expect(stripGlobSuffix("backend/app/**")).toBe("backend/app");
+  });
+
+  it("keeps non-glob paths", () => {
+    expect(stripGlobSuffix("cli/main.go")).toBe("cli/main.go");
+  });
+});
+```
+
+**Step 4: Configure vitest to handle vscode import**
+
+The `utils.ts` file imports only `fs` (no vscode), so vitest works directly. But future test files may need a vscode mock. For now, no extra config needed — vitest resolves the pure-function tests natively.
+
+**Step 5: Run tests**
+
+```bash
+cd vscode-c3-nav && npm test
+```
+
+Expected: 5 passing tests.
+
+**Step 6: Commit**
+
+```bash
+git add vscode-c3-nav/package.json vscode-c3-nav/package-lock.json vscode-c3-nav/src/__tests__/utils.test.ts
+git commit -m "test: add vitest and smoke tests for utils"
+```
+
+---
+
+## Task 2: Extend DocEntry Interface and parseFrontmatter
+
+**Files:**
+- Modify: `vscode-c3-nav/src/utils.ts:6-11` (DocEntry interface)
+- Modify: `vscode-c3-nav/src/utils.ts:17-49` (parseFrontmatter function)
+- Modify: `vscode-c3-nav/src/__tests__/utils.test.ts`
+
+**Step 1: Write failing tests for new frontmatter fields**
+
+Add to `src/__tests__/utils.test.ts`:
+```typescript
+import { parseFrontmatter } from "../utils";
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { beforeEach, afterEach } from "vitest";
+
+describe("parseFrontmatter", () => {
+  const tmpDir = join(__dirname, "__tmp__");
+  beforeEach(() => mkdirSync(tmpDir, { recursive: true }));
+  afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+  it("parses component frontmatter with all fields", () => {
+    const file = join(tmpDir, "c3-113-check-cmd.md");
+    writeFileSync(file, `---
+id: c3-113
+title: check-cmd
+type: component
+category: feature
+parent: c3-1
+goal: Validate docs
+status: active
+uses: [c3-101, c3-102, c3-104]
+---
+# check-cmd`);
+
+    const result = parseFrontmatter(file);
+    expect(result.title).toBe("check-cmd");
+    expect(result.type).toBe("component");
+    expect(result.category).toBe("feature");
+    expect(result.parent).toBe("c3-1");
+    expect(result.status).toBe("active");
+    expect(result.uses).toEqual(["c3-101", "c3-102", "c3-104"]);
+  });
+
+  it("parses ref frontmatter with via field", () => {
+    const file = join(tmpDir, "ref-test.md");
+    writeFileSync(file, `---
+id: ref-test
+title: Test Ref
+type: ref
+goal: A test ref
+via: [c3-101, c3-103]
+---
+# Test`);
+
+    const result = parseFrontmatter(file);
+    expect(result.type).toBe("ref");
+    expect(result.via).toEqual(["c3-101", "c3-103"]);
+    expect(result.uses).toBeUndefined();
+  });
+
+  it("parses ADR frontmatter", () => {
+    const file = join(tmpDir, "adr-test.md");
+    writeFileSync(file, `---
+id: adr-00000000-c3-adoption
+title: C3 Adoption
+type: adr
+status: in-progress
+---
+# ADR`);
+
+    const result = parseFrontmatter(file);
+    expect(result.type).toBe("adr");
+    expect(result.status).toBe("in-progress");
+  });
+
+  it("defaults status to active when not specified", () => {
+    const file = join(tmpDir, "c3-101.md");
+    writeFileSync(file, `---
+id: c3-101
+title: Frontmatter
+type: component
+category: foundation
+parent: c3-1
+goal: Parse frontmatter
+---`);
+
+    const result = parseFrontmatter(file);
+    expect(result.status).toBe("active");
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+cd vscode-c3-nav && npm test
+```
+
+Expected: FAIL — `type`, `category`, `parent`, `uses`, `via`, `status` are not parsed yet.
+
+**Step 3: Extend DocEntry interface**
+
+In `utils.ts`, replace the DocEntry interface (lines 6-11):
+```typescript
+export interface DocEntry {
+  path: string;
+  title?: string;
+  goal?: string;
+  summary?: string;
+  type?: "container" | "component" | "ref" | "adr";
+  category?: "foundation" | "feature";
+  parent?: string;
+  uses?: string[];
+  via?: string[];
+  status?: string;
+}
+```
+
+**Step 4: Extend parseFrontmatter**
+
+In `utils.ts`, update parseFrontmatter return type and add parsing for new fields. After the existing `summaryMatch` block (line 46), add:
+
+```typescript
+const typeMatch = fm.match(/^type:\s*(.+)$/m);
+if (typeMatch) {
+  result.type = stripYamlQuotes(typeMatch[1].trim()) as DocEntry["type"];
+}
+
+const categoryMatch = fm.match(/^category:\s*(.+)$/m);
+if (categoryMatch) {
+  result.category = stripYamlQuotes(categoryMatch[1].trim()) as DocEntry["category"];
+}
+
+const parentMatch = fm.match(/^parent:\s*(.+)$/m);
+if (parentMatch) {
+  result.parent = stripYamlQuotes(parentMatch[1].trim());
+}
+
+const usesMatch = fm.match(/^uses:\s*\[([^\]]*)\]$/m);
+if (usesMatch) {
+  result.uses = usesMatch[1].split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+const viaMatch = fm.match(/^via:\s*\[([^\]]*)\]$/m);
+if (viaMatch) {
+  result.via = viaMatch[1].split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+const statusMatch = fm.match(/^status:\s*(.+)$/m);
+result.status = statusMatch ? stripYamlQuotes(statusMatch[1].trim()) : "active";
+```
+
+Also update the return type signature from `Pick<DocEntry, "title" | "goal" | "summary">` to `Omit<DocEntry, "path">`.
+
+Update the `result` variable type to match: `const result: Omit<DocEntry, "path"> = {};`
+
+**Step 5: Run tests**
+
+```bash
+cd vscode-c3-nav && npm test
+```
+
+Expected: All tests pass.
+
+**Step 6: Verify TypeScript compiles**
+
+```bash
+cd vscode-c3-nav && npx tsc -p ./ --noEmit
+```
+
+Expected: Clean compile (no errors).
+
+**Step 7: Commit**
+
+```bash
+git add vscode-c3-nav/src/utils.ts vscode-c3-nav/src/__tests__/utils.test.ts
+git commit -m "feat: extend DocEntry with type, category, parent, uses, via, status"
+```
+
+---
+
+## Task 3: Handle README.md and ADR Filenames in DocMap
+
+**Files:**
+- Modify: `vscode-c3-nav/src/utils.ts:64-76` (extractIdFromFilename)
+- Modify: `vscode-c3-nav/src/docMap.ts:18-34` (build method)
+- Modify: `vscode-c3-nav/src/__tests__/utils.test.ts`
+
+**Context:** Currently `extractIdFromFilename("README.md")` returns `undefined`, so container docs (c3-0, c3-1, c3-2) are never indexed. ADR filenames like `adr-00000000-c3-adoption.md` are also not matched. We need both in the DocMap for the tree view.
+
+**Step 1: Write failing tests for ADR filename extraction**
+
+Add to `src/__tests__/utils.test.ts` in the `extractIdFromFilename` describe block:
+```typescript
+it("extracts ADR ID from filename", () => {
+  expect(extractIdFromFilename("adr-00000000-c3-adoption.md")).toBe("adr-00000000-c3-adoption");
+});
+
+it("extracts ADR ID with date prefix", () => {
+  expect(extractIdFromFilename("adr-20260309-add-diff-cmd.md")).toBe("adr-20260309-add-diff-cmd");
+});
+```
+
+**Step 2: Run tests — verify they fail**
+
+```bash
+cd vscode-c3-nav && npm test
+```
+
+Expected: FAIL — ADR pattern not handled.
+
+**Step 3: Add ADR pattern to extractIdFromFilename**
+
+In `utils.ts`, add before the final `return undefined` in `extractIdFromFilename`:
+```typescript
+const adrMatch = filename.match(/^(adr-[\w-]+)\.md$/);
+if (adrMatch) {
+  return adrMatch[1];
+}
+```
+
+**Step 4: Run tests — verify they pass**
+
+```bash
+cd vscode-c3-nav && npm test
+```
+
+Expected: All tests pass.
+
+**Step 5: Handle README.md in DocMap.build()**
+
+README.md files need special handling — the ID comes from frontmatter, not filename. In `docMap.ts`, modify the `build()` method. Replace lines 18-34:
+
+```typescript
+for (const file of files) {
+  const filename = path.basename(file.fsPath);
+  let id = extractIdFromFilename(filename);
+
+  // README.md files store their ID in frontmatter (containers like c3-0, c3-1, c3-2)
+  if (!id && filename === "README.md") {
+    const frontmatter = parseFrontmatter(file.fsPath);
+    if (frontmatter.type === "container" || (frontmatter as Record<string, unknown>).id) {
+      // Read id directly from frontmatter
+      id = this.readFrontmatterId(file.fsPath);
+    }
+    if (!id) {
+      continue;
+    }
+    if (this.map.has(id)) {
+      console.warn(`[C3 Nav] Duplicate ID "${id}" — keeping first match, skipping ${file.fsPath}`);
+      continue;
+    }
+    this.map.set(id, { path: file.fsPath, ...frontmatter });
+    continue;
+  }
+
+  if (!id) {
+    continue;
+  }
+
+  if (this.map.has(id)) {
+    console.warn(`[C3 Nav] Duplicate ID "${id}" — keeping first match, skipping ${file.fsPath}`);
+    continue;
+  }
+
+  const frontmatter = parseFrontmatter(file.fsPath);
+  this.map.set(id, { path: file.fsPath, ...frontmatter });
+}
+```
+
+Add helper method to `DocMap` class:
+```typescript
+private readFrontmatterId(filePath: string): string | undefined {
+  const fs = require("fs");
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return undefined;
+  }
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) {
+    return undefined;
+  }
+  const idMatch = fmMatch[1].match(/^id:\s*(.+)$/m);
+  return idMatch ? idMatch[1].trim() : undefined;
+}
+```
+
+**Step 6: Verify TypeScript compiles**
+
+```bash
+cd vscode-c3-nav && npx tsc -p ./ --noEmit
+```
+
+**Step 7: Commit**
+
+```bash
+git add vscode-c3-nav/src/utils.ts vscode-c3-nav/src/docMap.ts vscode-c3-nav/src/__tests__/utils.test.ts
+git commit -m "feat: handle README.md and ADR filenames in DocMap"
+```
+
+---
+
+## Task 4: Add Markdown Context Detection Utilities
+
+**Files:**
+- Modify: `vscode-c3-nav/src/utils.ts`
+- Modify: `vscode-c3-nav/src/__tests__/utils.test.ts`
+
+**Context:** CodeLens in markdown needs to know: "Is this line inside frontmatter? Is it a markdown table row?" So we can apply smart placement (CodeLens in frontmatter + tables, not in prose).
+
+**Step 1: Write failing tests**
+
+Add to `src/__tests__/utils.test.ts`:
+```typescript
+import { isInFrontmatter, isMarkdownTableRow, getBacktickPathAtPosition } from "../utils";
+
+describe("isInFrontmatter", () => {
+  const lines = [
+    "---",           // 0
+    "id: c3-113",    // 1
+    "parent: c3-1",  // 2
+    "uses: [c3-101]",// 3
+    "---",           // 4
+    "",              // 5
+    "# Title",       // 6
+    "Body text c3-101", // 7
+  ];
+
+  it("returns true for lines inside frontmatter", () => {
+    expect(isInFrontmatter(lines, 1)).toBe(true);
+    expect(isInFrontmatter(lines, 2)).toBe(true);
+    expect(isInFrontmatter(lines, 3)).toBe(true);
+  });
+
+  it("returns false for frontmatter delimiters", () => {
+    expect(isInFrontmatter(lines, 0)).toBe(false);
+    expect(isInFrontmatter(lines, 4)).toBe(false);
+  });
+
+  it("returns false for lines outside frontmatter", () => {
+    expect(isInFrontmatter(lines, 5)).toBe(false);
+    expect(isInFrontmatter(lines, 6)).toBe(false);
+    expect(isInFrontmatter(lines, 7)).toBe(false);
+  });
+});
+
+describe("isMarkdownTableRow", () => {
+  it("matches table data rows", () => {
+    expect(isMarkdownTableRow("| IN (uses) | Entity graph | c3-102 |")).toBe(true);
+  });
+
+  it("does not match separator rows", () => {
+    expect(isMarkdownTableRow("|-----------|------|---------|")).toBe(false);
+  });
+
+  it("does not match non-table lines", () => {
+    expect(isMarkdownTableRow("Some text mentioning c3-101")).toBe(false);
+  });
+});
+
+describe("getBacktickPathAtPosition", () => {
+  it("extracts path from backtick-wrapped text", () => {
+    const line = "| `cli/internal/frontmatter/parse.go` | Parses YAML |";
+    const result = getBacktickPathAtPosition(line, 10);
+    expect(result).toBeDefined();
+    expect(result!.rawPath).toBe("cli/internal/frontmatter/parse.go");
+    expect(result!.folderPath).toBe("cli/internal/frontmatter/parse.go");
+  });
+
+  it("returns undefined when position is outside backticks", () => {
+    const line = "| `cli/main.go` | Main entry |";
+    const result = getBacktickPathAtPosition(line, 25);
+    expect(result).toBeUndefined();
+  });
+
+  it("strips glob suffix from backtick paths", () => {
+    const line = "Maps to `backend-core/app/**` for coverage";
+    const result = getBacktickPathAtPosition(line, 15);
+    expect(result!.rawPath).toBe("backend-core/app/**");
+    expect(result!.folderPath).toBe("backend-core/app");
+  });
+});
+```
+
+**Step 2: Run tests — verify they fail**
+
+```bash
+cd vscode-c3-nav && npm test
+```
+
+**Step 3: Implement the utilities**
+
+Add to `utils.ts`:
+
+```typescript
+/**
+ * Check if a line index is inside the YAML frontmatter block.
+ * Frontmatter is between the first `---` (line 0) and the next `---`.
+ * Returns true for content lines, false for delimiters and outside.
+ */
+export function isInFrontmatter(lines: string[], lineIndex: number): boolean {
+  if (lines[0] !== "---") {
+    return false;
+  }
+  // Find the closing ---
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === "---") {
+      return lineIndex > 0 && lineIndex < i;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check if a line is a markdown table data row (not a separator row).
+ * Table rows start and end with | and contain non-dash content.
+ */
+export function isMarkdownTableRow(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("|") || !trimmed.endsWith("|")) {
+    return false;
+  }
+  // Separator rows contain only |, -, :, and spaces
+  return !/^\|[\s|:-]+\|$/.test(trimmed);
+}
+
+/**
+ * Get a backtick-wrapped file path at a given position in a line.
+ * Matches patterns like `cli/internal/frontmatter/parse.go`.
+ * Returns path info with glob suffix stripped for navigation.
+ */
+export function getBacktickPathAtPosition(
+  lineText: string,
+  characterPos: number
+): { rawPath: string; folderPath: string; start: number; end: number } | undefined {
+  const regex = /`([^`]+\.[a-z]+[^`]*)`|`([^`]+\/[^`]+)`/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(lineText)) !== null) {
+    const pathValue = match[1] || match[2];
+    const start = match.index + 1; // after opening backtick
+    const end = start + pathValue.length;
+    if (characterPos >= start && characterPos <= end) {
+      return {
+        rawPath: pathValue,
+        folderPath: stripGlobSuffix(pathValue),
+        start,
+        end,
+      };
+    }
+  }
+
+  return undefined;
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+cd vscode-c3-nav && npm test
+```
+
+Expected: All tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add vscode-c3-nav/src/utils.ts vscode-c3-nav/src/__tests__/utils.test.ts
+git commit -m "feat: add markdown context detection utilities"
+```
+
+---
+
+## Task 5: Extend CodeLensProvider for Markdown
+
+**Files:**
+- Modify: `vscode-c3-nav/src/codeLensProvider.ts`
+
+**Context:** Currently only processes YAML files. Add markdown smart placement: CodeLens in frontmatter fields (`parent`, `uses`, `via`) and markdown table rows. No CodeLens in prose paragraphs.
+
+**Step 1: Update imports**
+
+At the top of `codeLensProvider.ts`, add:
+```typescript
+import { C3_ID_PATTERN, getPathAtPosition, isInFrontmatter, isMarkdownTableRow, getBacktickPathAtPosition } from "./utils";
+```
+
+**Step 2: Add markdown detection**
+
+In the `provideCodeLenses` method, after `const lenses: vscode.CodeLens[] = [];`, add:
+```typescript
+const isMarkdown = document.languageId === "markdown";
+const allLines = isMarkdown
+  ? Array.from({ length: document.lineCount }, (_, i) => document.lineAt(i).text)
+  : [];
+```
+
+**Step 3: Add smart placement guard for C3 ID lenses**
+
+Inside the line loop, before the C3 ID regex matching, add a guard:
+```typescript
+// In markdown: only show CodeLens in frontmatter and table rows
+if (isMarkdown) {
+  const inFrontmatter = isInFrontmatter(allLines, i);
+  const inTable = isMarkdownTableRow(line.text);
+  if (!inFrontmatter && !inTable) {
+    // Still process for path lenses in tables, skip C3 ID CodeLens in prose
+    continue;
+  }
+}
+```
+
+Wait — this would skip path lenses too. Better approach: restructure the loop to check context per-match-type. Here's the full replacement for `provideCodeLenses`:
+
+```typescript
+provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
+  const lenses: vscode.CodeLens[] = [];
+  const isMarkdown = document.languageId === "markdown";
+  const allLines = isMarkdown
+    ? Array.from({ length: document.lineCount }, (_, i) => document.lineAt(i).text)
+    : [];
+
+  for (let i = 0; i < document.lineCount; i++) {
+    const line = document.lineAt(i);
+    const showIdLens = !isMarkdown || isInFrontmatter(allLines, i) || isMarkdownTableRow(line.text);
+    const showPathLens = !isMarkdown || isInFrontmatter(allLines, i) || isMarkdownTableRow(line.text);
+
+    // C3 ID lenses (frontmatter + tables in markdown, everywhere in YAML)
+    if (showIdLens) {
+      const regex = new RegExp(C3_ID_PATTERN.source, "g");
+      let match: RegExpExecArray | null;
+
+      while ((match = regex.exec(line.text)) !== null) {
+        const id = match[0];
+        const entry = this.docMap.get(id);
+        if (!entry) {
+          continue;
+        }
+
+        const range = new vscode.Range(i, match.index, i, match.index + id.length);
+        const filename = path.basename(entry.path);
+        const title = entry.title ? `${entry.title} (${filename})` : filename;
+
+        lenses.push(
+          new vscode.CodeLens(range, {
+            title: `→ ${title}`,
+            command: "c3Nav.openDocument",
+            arguments: [entry.path],
+          })
+        );
+      }
+    }
+
+    // Path lenses — YAML: quoted paths, Markdown: backtick paths in tables
+    if (isMarkdown) {
+      if (showPathLens) {
+        const pathMatch = getBacktickPathAtPosition(line.text, line.text.indexOf("`") + 1);
+        if (pathMatch) {
+          const range = new vscode.Range(i, pathMatch.start, i, pathMatch.end);
+          lenses.push(
+            new vscode.CodeLens(range, {
+              title: `→ Open: ${pathMatch.folderPath}`,
+              command: "c3Nav.revealPath",
+              arguments: [pathMatch.folderPath],
+            })
+          );
+        }
+      }
+    } else {
+      const pathMatch = getPathAtPosition(line.text, line.text.indexOf('"') + 1);
+      if (pathMatch) {
+        const range = new vscode.Range(i, pathMatch.start, i, pathMatch.end);
+        lenses.push(
+          new vscode.CodeLens(range, {
+            title: `→ Open: ${pathMatch.folderPath}`,
+            command: "c3Nav.revealPath",
+            arguments: [pathMatch.folderPath],
+          })
+        );
+      }
+    }
+  }
+
+  return lenses;
+}
+```
+
+**Step 4: Verify TypeScript compiles**
+
+```bash
+cd vscode-c3-nav && npx tsc -p ./ --noEmit
+```
+
+**Step 5: Commit**
+
+```bash
+git add vscode-c3-nav/src/codeLensProvider.ts
+git commit -m "feat: extend CodeLensProvider for markdown smart placement"
+```
+
+---
+
+## Task 6: Extend DefinitionProvider for Markdown
+
+**Files:**
+- Modify: `vscode-c3-nav/src/definitionProvider.ts`
+
+**Context:** Add backtick path support for markdown files. C3 ID navigation already works (regex matches in any text). Paths in markdown use backticks instead of quotes.
+
+**Step 1: Update imports**
+
+```typescript
+import { getIdAtPosition, getPathAtPosition, getBacktickPathAtPosition } from "./utils";
+```
+
+**Step 2: Add backtick path handling**
+
+In `provideDefinition`, after the existing quoted path block, add a backtick path fallback:
+
+```typescript
+// Try backtick path (markdown files)
+const backtickMatch = getBacktickPathAtPosition(line, position.character);
+if (backtickMatch) {
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  if (workspaceFolder) {
+    const absPath = path.join(workspaceFolder.uri.fsPath, backtickMatch.folderPath);
+    return new vscode.Location(vscode.Uri.file(absPath), new vscode.Position(0, 0));
+  }
+}
+```
+
+**Step 3: Verify TypeScript compiles**
+
+```bash
+cd vscode-c3-nav && npx tsc -p ./ --noEmit
+```
+
+**Step 4: Commit**
+
+```bash
+git add vscode-c3-nav/src/definitionProvider.ts
+git commit -m "feat: extend DefinitionProvider with backtick path support"
+```
+
+---
+
+## Task 7: Extend HoverProvider for Markdown
+
+**Files:**
+- Modify: `vscode-c3-nav/src/hoverProvider.ts`
+
+**Context:** Add backtick path hover support. C3 ID hover already works. Also add status badge to doc hover cards.
+
+**Step 1: Update imports**
+
+```typescript
+import { getIdAtPosition, getPathAtPosition, getBacktickPathAtPosition } from "./utils";
+```
+
+**Step 2: Add backtick path hover**
+
+In `provideHover`, after the existing `pathMatch` block, add:
+
+```typescript
+// Try backtick path (markdown files)
+const backtickMatch = getBacktickPathAtPosition(line, position.character);
+if (backtickMatch) {
+  return this.buildPathHover(backtickMatch);
+}
+```
+
+**Step 3: Add status to doc hover card**
+
+In `buildDocHover`, after the goal block (line 49), add:
+
+```typescript
+if (entry.status && entry.status !== "active") {
+  md.appendMarkdown(`*Status:* \`${entry.status}\`\n\n`);
+}
+```
+
+Update the `entry` parameter type to include `status`:
+```typescript
+entry: { path: string; title?: string; goal?: string; summary?: string; status?: string }
+```
+
+**Step 4: Verify TypeScript compiles**
+
+```bash
+cd vscode-c3-nav && npx tsc -p ./ --noEmit
+```
+
+**Step 5: Commit**
+
+```bash
+git add vscode-c3-nav/src/hoverProvider.ts
+git commit -m "feat: extend HoverProvider with backtick paths and status badge"
+```
+
+---
+
+## Task 8: Register Markdown Document Selector
+
+**Files:**
+- Modify: `vscode-c3-nav/src/extension.ts`
+
+**Context:** All three providers need to be registered for `.c3/**/*.md` in addition to `.c3/**/*.yaml`.
+
+**Step 1: Add markdown selector**
+
+In `extension.ts`, after the existing `YAML_IN_C3` constant (line 9-12), add:
+
+```typescript
+const MD_IN_C3: vscode.DocumentSelector = {
+  scheme: "file",
+  pattern: "**/.c3/**/*.md",
+};
+```
+
+**Step 2: Register providers for both selectors**
+
+Replace the three provider registrations (lines 30-32) with:
+
+```typescript
+vscode.languages.registerCodeLensProvider(YAML_IN_C3, codeLensProvider),
+vscode.languages.registerCodeLensProvider(MD_IN_C3, codeLensProvider),
+vscode.languages.registerDefinitionProvider(YAML_IN_C3, new C3DefinitionProvider(docMap)),
+vscode.languages.registerDefinitionProvider(MD_IN_C3, new C3DefinitionProvider(docMap)),
+vscode.languages.registerHoverProvider(YAML_IN_C3, new C3HoverProvider(docMap)),
+vscode.languages.registerHoverProvider(MD_IN_C3, new C3HoverProvider(docMap)),
+```
+
+**Step 3: Verify TypeScript compiles**
+
+```bash
+cd vscode-c3-nav && npx tsc -p ./ --noEmit
+```
+
+**Step 4: Commit**
+
+```bash
+git add vscode-c3-nav/src/extension.ts
+git commit -m "feat: register providers for markdown files in .c3/"
+```
+
+---
+
+## Task 9: Create TreeViewProvider — Data Structure
+
+**Files:**
+- Create: `vscode-c3-nav/src/treeViewProvider.ts`
+
+**Context:** Build the tree data provider that reads from DocMap and renders hierarchy or flat view. This task covers the data model and tree structure. Next task adds context menu actions.
+
+**Step 1: Create treeViewProvider.ts**
+
+```typescript
+import * as vscode from "vscode";
+import * as path from "path";
+import { DocMap } from "./docMap";
+import { DocEntry } from "./utils";
+
+type ViewMode = "hierarchy" | "flat";
+
+interface C3TreeItem {
+  id: string;
+  entry: DocEntry;
+}
+
+export class C3TreeViewProvider implements vscode.TreeDataProvider<string> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<string | undefined>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private viewMode: ViewMode = "hierarchy";
+
+  constructor(private docMap: DocMap) {}
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
+  toggleViewMode(): void {
+    this.viewMode = this.viewMode === "hierarchy" ? "flat" : "hierarchy";
+    this.refresh();
+  }
+
+  getViewMode(): ViewMode {
+    return this.viewMode;
+  }
+
+  getTreeItem(element: string): vscode.TreeItem {
+    // Group headers (non-ID nodes)
+    if (element.startsWith("__group:")) {
+      const label = element.replace("__group:", "");
+      const item = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.Expanded);
+      item.contextValue = "group";
+      return item;
+    }
+
+    // Category sub-headers
+    if (element.startsWith("__category:")) {
+      const parts = element.replace("__category:", "").split(":");
+      const label = parts[1].charAt(0).toUpperCase() + parts[1].slice(1);
+      const item = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.Expanded);
+      item.contextValue = "category";
+      return item;
+    }
+
+    const entry = this.docMap.get(element);
+    if (!entry) {
+      return new vscode.TreeItem(element);
+    }
+
+    const hasChildren = this.getChildIds(element).length > 0;
+    const collapsible = hasChildren
+      ? vscode.TreeItemCollapsibleState.Expanded
+      : vscode.TreeItemCollapsibleState.None;
+
+    const label = entry.title ? `${element} · ${entry.title}` : element;
+    const item = new vscode.TreeItem(label, collapsible);
+
+    // Status badge
+    if (entry.status && entry.status !== "active") {
+      item.description = `[${entry.status}]`;
+    }
+
+    // Goal as tooltip
+    if (entry.goal) {
+      item.tooltip = entry.goal;
+    }
+
+    // Click opens the document
+    item.command = {
+      command: "c3Nav.openDocument",
+      title: "Open Document",
+      arguments: [entry.path],
+    };
+
+    item.contextValue = entry.type || "document";
+
+    return item;
+  }
+
+  getChildren(element?: string): string[] {
+    if (!element) {
+      return this.viewMode === "hierarchy" ? this.getHierarchyRoots() : this.getFlatGroups();
+    }
+
+    if (this.viewMode === "flat") {
+      return this.getFlatGroupChildren(element);
+    }
+
+    return this.getHierarchyChildren(element);
+  }
+
+  // --- Hierarchy mode ---
+
+  private getHierarchyRoots(): string[] {
+    const roots: string[] = [];
+
+    // Find root container (c3-0)
+    for (const [id, entry] of this.docMap.entries()) {
+      if (entry.type === "container" && !entry.parent) {
+        roots.push(id);
+      }
+    }
+
+    // Add References and ADRs groups
+    if (this.hasEntriesOfType("ref")) {
+      roots.push("__group:References");
+    }
+    if (this.hasEntriesOfType("adr")) {
+      roots.push("__group:ADRs");
+    }
+
+    return roots;
+  }
+
+  private getHierarchyChildren(element: string): string[] {
+    if (element.startsWith("__group:")) {
+      const group = element.replace("__group:", "");
+      if (group === "References") {
+        return this.getEntriesOfType("ref");
+      }
+      if (group === "ADRs") {
+        return this.getEntriesOfType("adr");
+      }
+      return [];
+    }
+
+    if (element.startsWith("__category:")) {
+      const parts = element.replace("__category:", "").split(":");
+      const parentId = parts[0];
+      const category = parts[1];
+      return this.getChildIds(parentId).filter((childId) => {
+        const entry = this.docMap.get(childId);
+        return entry?.category === category;
+      });
+    }
+
+    // For containers: group children by category if they have categories
+    const children = this.getChildIds(element);
+    const categories = new Set<string>();
+    for (const childId of children) {
+      const entry = this.docMap.get(childId);
+      if (entry?.category) {
+        categories.add(entry.category);
+      }
+    }
+
+    if (categories.size > 1) {
+      // Group by category
+      return Array.from(categories)
+        .sort()
+        .map((cat) => `__category:${element}:${cat}`);
+    }
+
+    // No categories or single category — list children directly
+    return children;
+  }
+
+  private getChildIds(parentId: string): string[] {
+    const children: string[] = [];
+    for (const [id, entry] of this.docMap.entries()) {
+      if (entry.parent === parentId && entry.type !== "ref" && entry.type !== "adr") {
+        children.push(id);
+      }
+    }
+    return children.sort();
+  }
+
+  // --- Flat mode ---
+
+  private getFlatGroups(): string[] {
+    const groups: string[] = [];
+    if (this.hasEntriesOfType("container")) {
+      groups.push("__group:Containers");
+    }
+    if (this.hasEntriesOfType("component")) {
+      groups.push("__group:Components");
+    }
+    if (this.hasEntriesOfType("ref")) {
+      groups.push("__group:References");
+    }
+    if (this.hasEntriesOfType("adr")) {
+      groups.push("__group:ADRs");
+    }
+    return groups;
+  }
+
+  private getFlatGroupChildren(element: string): string[] {
+    const group = element.replace("__group:", "");
+    const typeMap: Record<string, string> = {
+      Containers: "container",
+      Components: "component",
+      References: "ref",
+      ADRs: "adr",
+    };
+    return this.getEntriesOfType(typeMap[group] || "");
+  }
+
+  // --- Helpers ---
+
+  private hasEntriesOfType(type: string): boolean {
+    for (const [, entry] of this.docMap.entries()) {
+      if (entry.type === type) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private getEntriesOfType(type: string): string[] {
+    const ids: string[] = [];
+    for (const [id, entry] of this.docMap.entries()) {
+      if (entry.type === type) {
+        ids.push(id);
+      }
+    }
+    return ids.sort();
+  }
+}
+```
+
+**Step 2: Verify TypeScript compiles**
+
+```bash
+cd vscode-c3-nav && npx tsc -p ./ --noEmit
+```
+
+**Step 3: Commit**
+
+```bash
+git add vscode-c3-nav/src/treeViewProvider.ts
+git commit -m "feat: create C3TreeViewProvider with hierarchy and flat modes"
+```
+
+---
+
+## Task 10: Add Context Menu Commands
+
+**Files:**
+- Modify: `vscode-c3-nav/src/treeViewProvider.ts`
+- Create: `vscode-c3-nav/src/treeCommands.ts`
+
+**Context:** Right-click actions: Show Dependencies, Show Dependents, Open in Code Map, Copy ID.
+
+**Step 1: Create treeCommands.ts**
+
+```typescript
+import * as vscode from "vscode";
+import * as path from "path";
+import { DocMap } from "./docMap";
+
+export function registerTreeCommands(
+  context: vscode.ExtensionContext,
+  docMap: DocMap,
+  workspaceFolder: vscode.WorkspaceFolder
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand("c3Nav.showDependencies", async (id: string) => {
+      const entry = docMap.get(id);
+      if (!entry?.uses || entry.uses.length === 0) {
+        vscode.window.showInformationMessage(`${id} has no dependencies.`);
+        return;
+      }
+
+      const items = entry.uses
+        .map((depId) => {
+          const dep = docMap.get(depId);
+          return {
+            label: depId,
+            description: dep?.title,
+            detail: dep?.goal,
+            depPath: dep?.path,
+          };
+        })
+        .filter((item) => item.depPath);
+
+      const selected = await vscode.window.showQuickPick(items, {
+        placeHolder: `Dependencies of ${id}`,
+      });
+
+      if (selected?.depPath) {
+        vscode.window.showTextDocument(vscode.Uri.file(selected.depPath), { preview: true });
+      }
+    }),
+
+    vscode.commands.registerCommand("c3Nav.showDependents", async (id: string) => {
+      const dependents: Array<{ id: string; title?: string; path: string }> = [];
+
+      for (const [entryId, entry] of docMap.entries()) {
+        if (entry.uses?.includes(id) || entry.via?.includes(id)) {
+          dependents.push({ id: entryId, title: entry.title, path: entry.path });
+        }
+      }
+
+      if (dependents.length === 0) {
+        vscode.window.showInformationMessage(`No components depend on ${id}.`);
+        return;
+      }
+
+      const items = dependents.map((dep) => ({
+        label: dep.id,
+        description: dep.title,
+        depPath: dep.path,
+      }));
+
+      const selected = await vscode.window.showQuickPick(items, {
+        placeHolder: `Dependents of ${id}`,
+      });
+
+      if (selected?.depPath) {
+        vscode.window.showTextDocument(vscode.Uri.file(selected.depPath), { preview: true });
+      }
+    }),
+
+    vscode.commands.registerCommand("c3Nav.openInCodeMap", async (id: string) => {
+      const codeMapPath = path.join(workspaceFolder.uri.fsPath, ".c3", "code-map.yaml");
+      const doc = await vscode.workspace.openTextDocument(codeMapPath);
+      const editor = await vscode.window.showTextDocument(doc, { preview: true });
+
+      // Find the line containing this ID
+      for (let i = 0; i < doc.lineCount; i++) {
+        if (doc.lineAt(i).text.includes(id)) {
+          const range = new vscode.Range(i, 0, i, 0);
+          editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+          editor.selection = new vscode.Selection(range.start, range.start);
+          break;
+        }
+      }
+    }),
+
+    vscode.commands.registerCommand("c3Nav.copyId", (id: string) => {
+      vscode.env.clipboard.writeText(id);
+      vscode.window.showInformationMessage(`Copied: ${id}`);
+    })
+  );
+}
+```
+
+**Step 2: Verify TypeScript compiles**
+
+```bash
+cd vscode-c3-nav && npx tsc -p ./ --noEmit
+```
+
+**Step 3: Commit**
+
+```bash
+git add vscode-c3-nav/src/treeCommands.ts
+git commit -m "feat: add tree context menu commands"
+```
+
+---
+
+## Task 11: Update package.json — Views, Commands, Menus
+
+**Files:**
+- Modify: `vscode-c3-nav/package.json`
+
+**Context:** Declare the tree view container, view, all new commands, and context menu bindings.
+
+**Step 1: Update package.json contributes section**
+
+Replace the entire `"contributes"` block:
+
+```json
+"contributes": {
+  "views": {
+    "explorer": [
+      {
+        "id": "c3Navigator",
+        "name": "C3 Architecture",
+        "when": "c3Nav.hasC3Folder"
+      }
+    ]
+  },
+  "commands": [
+    {
+      "command": "c3Nav.openDocument",
+      "title": "C3: Open Architecture Document"
+    },
+    {
+      "command": "c3Nav.revealPath",
+      "title": "C3: Reveal Path"
+    },
+    {
+      "command": "c3Nav.toggleViewMode",
+      "title": "C3: Toggle Hierarchy/Flat View",
+      "icon": "$(list-tree)"
+    },
+    {
+      "command": "c3Nav.showDependencies",
+      "title": "Show Dependencies"
+    },
+    {
+      "command": "c3Nav.showDependents",
+      "title": "Show Dependents"
+    },
+    {
+      "command": "c3Nav.openInCodeMap",
+      "title": "Open in Code Map"
+    },
+    {
+      "command": "c3Nav.copyId",
+      "title": "Copy ID"
+    }
+  ],
+  "menus": {
+    "view/title": [
+      {
+        "command": "c3Nav.toggleViewMode",
+        "when": "view == c3Navigator",
+        "group": "navigation"
+      }
+    ],
+    "view/item/context": [
+      {
+        "command": "c3Nav.showDependencies",
+        "when": "view == c3Navigator && viewItem =~ /component|container/",
+        "group": "c3nav@1"
+      },
+      {
+        "command": "c3Nav.showDependents",
+        "when": "view == c3Navigator && viewItem =~ /component|ref/",
+        "group": "c3nav@2"
+      },
+      {
+        "command": "c3Nav.openInCodeMap",
+        "when": "view == c3Navigator && viewItem =~ /component|container|ref/",
+        "group": "c3nav@3"
+      },
+      {
+        "command": "c3Nav.copyId",
+        "when": "view == c3Navigator && viewItem != group && viewItem != category",
+        "group": "c3nav@4"
+      }
+    ]
+  }
+}
+```
+
+**Step 2: Verify JSON is valid**
+
+```bash
+cd vscode-c3-nav && node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'));console.log('Valid JSON')"
+```
+
+**Step 3: Commit**
+
+```bash
+git add vscode-c3-nav/package.json
+git commit -m "feat: declare tree view, commands, and context menus in package.json"
+```
+
+---
+
+## Task 12: Wire Everything in extension.ts
+
+**Files:**
+- Modify: `vscode-c3-nav/src/extension.ts`
+
+**Context:** Register the tree view provider, toggle command, context commands, and set the `c3Nav.hasC3Folder` context for conditional view visibility.
+
+**Step 1: Replace extension.ts**
+
+```typescript
+import * as vscode from "vscode";
+import * as path from "path";
+import * as fs from "fs";
+import { DocMap } from "./docMap";
+import { C3CodeLensProvider } from "./codeLensProvider";
+import { C3DefinitionProvider } from "./definitionProvider";
+import { C3HoverProvider } from "./hoverProvider";
+import { C3TreeViewProvider } from "./treeViewProvider";
+import { registerTreeCommands } from "./treeCommands";
+
+const YAML_IN_C3: vscode.DocumentSelector = {
+  scheme: "file",
+  pattern: "**/.c3/**/*.yaml",
+};
+
+const MD_IN_C3: vscode.DocumentSelector = {
+  scheme: "file",
+  pattern: "**/.c3/**/*.md",
+};
+
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  if (!workspaceFolder) {
+    return;
+  }
+
+  // Set context for conditional view visibility
+  vscode.commands.executeCommand("setContext", "c3Nav.hasC3Folder", true);
+
+  const docMap = new DocMap();
+  await docMap.build(workspaceFolder);
+
+  // CodeLens
+  const codeLensProvider = new C3CodeLensProvider(docMap);
+  docMap.onDidRebuild(() => codeLensProvider.refresh());
+
+  // Tree View
+  const treeViewProvider = new C3TreeViewProvider(docMap);
+  docMap.onDidRebuild(() => treeViewProvider.refresh());
+
+  context.subscriptions.push(
+    // File watching
+    docMap.startWatching(workspaceFolder),
+
+    // CodeLens for YAML and Markdown
+    vscode.languages.registerCodeLensProvider(YAML_IN_C3, codeLensProvider),
+    vscode.languages.registerCodeLensProvider(MD_IN_C3, codeLensProvider),
+
+    // Definition for YAML and Markdown
+    vscode.languages.registerDefinitionProvider(YAML_IN_C3, new C3DefinitionProvider(docMap)),
+    vscode.languages.registerDefinitionProvider(MD_IN_C3, new C3DefinitionProvider(docMap)),
+
+    // Hover for YAML and Markdown
+    vscode.languages.registerHoverProvider(YAML_IN_C3, new C3HoverProvider(docMap)),
+    vscode.languages.registerHoverProvider(MD_IN_C3, new C3HoverProvider(docMap)),
+
+    // Tree view
+    vscode.window.createTreeView("c3Navigator", {
+      treeDataProvider: treeViewProvider,
+      showCollapseAll: true,
+    }),
+
+    // Commands
+    vscode.commands.registerCommand("c3Nav.openDocument", (filePath: string) => {
+      const uri = vscode.Uri.file(filePath);
+      vscode.window.showTextDocument(uri, { preview: true });
+    }),
+    vscode.commands.registerCommand("c3Nav.revealPath", async (relativePath: string) => {
+      const absPath = path.join(workspaceFolder.uri.fsPath, relativePath);
+      const uri = vscode.Uri.file(absPath);
+
+      if (fs.existsSync(absPath) && fs.statSync(absPath).isDirectory()) {
+        await vscode.commands.executeCommand("revealInExplorer", uri);
+        await vscode.commands.executeCommand("list.expand");
+      } else if (fs.existsSync(absPath)) {
+        vscode.window.showTextDocument(uri, { preview: true });
+      } else {
+        vscode.window.showWarningMessage(`Path not found: ${relativePath}`);
+      }
+    }),
+    vscode.commands.registerCommand("c3Nav.toggleViewMode", () => {
+      treeViewProvider.toggleViewMode();
+    })
+  );
+
+  // Register tree context menu commands
+  registerTreeCommands(context, docMap, workspaceFolder);
+
+  console.log("[C3 Nav] Extension activated");
+}
+
+export function deactivate(): void {
+  // cleanup handled by disposables
+}
+```
+
+**Step 2: Verify TypeScript compiles**
+
+```bash
+cd vscode-c3-nav && npx tsc -p ./ --noEmit
+```
+
+**Step 3: Run tests**
+
+```bash
+cd vscode-c3-nav && npm test
+```
+
+Expected: All tests still pass.
+
+**Step 4: Commit**
+
+```bash
+git add vscode-c3-nav/src/extension.ts
+git commit -m "feat: wire tree view, markdown providers, and all commands"
+```
+
+---
+
+## Task 13: Build and Smoke Test
+
+**Step 1: Full compile**
+
+```bash
+cd vscode-c3-nav && npx tsc -p ./
+```
+
+Expected: Clean compile, output in `out/`.
+
+**Step 2: Package extension**
+
+```bash
+cd vscode-c3-nav && npm run package
+```
+
+Expected: Produces `c3-nav.vsix` without errors.
+
+**Step 3: Run all tests**
+
+```bash
+cd vscode-c3-nav && npm test
+```
+
+Expected: All tests pass.
+
+**Step 4: Bump version to 0.2.0**
+
+In `package.json`, change `"version": "0.1.0"` to `"version": "0.2.0"`.
+
+Update description:
+```json
+"description": "Navigate C3 architecture documents — cross-reference links, hover previews, and tree view for .c3/ files"
+```
+
+**Step 5: Final commit**
+
+```bash
+git add vscode-c3-nav/
+git commit -m "feat(vscode-c3-nav): v0.2.0 — markdown navigation and tree view"
+```
+
+---
+
+## Summary
+
+| Task | What | Commit |
+|------|------|--------|
+| 1 | Test framework setup | `test: add vitest and smoke tests for utils` |
+| 2 | Extend DocEntry + parseFrontmatter | `feat: extend DocEntry with type, category, parent, uses, via, status` |
+| 3 | README.md + ADR filename handling | `feat: handle README.md and ADR filenames in DocMap` |
+| 4 | Markdown context detection utils | `feat: add markdown context detection utilities` |
+| 5 | CodeLensProvider for markdown | `feat: extend CodeLensProvider for markdown smart placement` |
+| 6 | DefinitionProvider for markdown | `feat: extend DefinitionProvider with backtick path support` |
+| 7 | HoverProvider for markdown | `feat: extend HoverProvider with backtick paths and status badge` |
+| 8 | Register markdown document selector | `feat: register providers for markdown files in .c3/` |
+| 9 | TreeViewProvider (data structure) | `feat: create C3TreeViewProvider with hierarchy and flat modes` |
+| 10 | Context menu commands | `feat: add tree context menu commands` |
+| 11 | package.json views/commands/menus | `feat: declare tree view, commands, and context menus in package.json` |
+| 12 | Wire everything in extension.ts | `feat: wire tree view, markdown providers, and all commands` |
+| 13 | Build, smoke test, version bump | `feat(vscode-c3-nav): v0.2.0 — markdown navigation and tree view` |

--- a/vscode-c3-nav/README.md
+++ b/vscode-c3-nav/README.md
@@ -1,6 +1,64 @@
 # C3 Architecture Navigator — VS Code Extension
 
-Navigate C3 architecture documents directly from your editor. Provides CodeLens links, hover previews, Ctrl+Click navigation, and Go to Definition for C3 IDs (`c3-*`, `ref-*`, `adr-*`) found in `.c3/` YAML files and code-map entries.
+Navigate C3 architecture documents directly from your editor. Cross-reference links, hover previews, tree view sidebar, and Ctrl+Click navigation for all `.c3/` files.
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| **CodeLens** | Inline links above C3 IDs in YAML and markdown — click to open the architecture doc |
+| **Hover** | Preview document title, goal, summary, and status on hover |
+| **Go to Definition** | Ctrl+Click on any C3 ID (`c3-*`, `ref-*`, `adr-*`) to jump to its document |
+| **Path Navigation** | Click file paths in `code-map.yaml` to open the source file or reveal folder |
+| **Tree View** | Sidebar panel showing C3 architecture hierarchy with toggle between hierarchy and flat views |
+| **Context Menu** | Right-click tree items for Show Dependencies, Show Dependents, Open in Code Map, Copy ID |
+
+## Tree View
+
+The **C3 Architecture** panel appears in the Explorer sidebar. Two modes toggled via toolbar button:
+
+**Hierarchy mode (default):**
+
+```
+c3-0 · C3 Design                          [active]
+├── c3-1 · Go CLI                          [active]
+│   ├── Foundation
+│   │   ├── c3-101 · Frontmatter Parser    [active]
+│   │   ├── c3-102 · Walker                [active]
+│   │   ├── c3-103 · Templates             [active]
+│   │   ├── c3-104 · Wiring               [active]
+│   │   └── c3-105 · Codemap Lib           [active]
+│   └── Feature
+│       ├── c3-110 · Init Cmd              [active]
+│       ├── c3-111 · Add Cmd               [active]
+│       ├── ...
+│       └── c3-117 · Diff Cmd              [provisioned]
+├── c3-2 · Claude Skill                    [active]
+│   ├── c3-201 · Skill Router              [active]
+│   └── c3-210 · Operation Refs            [active]
+├── References
+│   ├── ref-frontmatter-docs
+│   ├── ref-embedded-templates
+│   └── ref-cross-compiled-binary
+└── ADRs
+    ├── adr-00000000 · C3 Adoption
+    └── adr-20260309 · Add Diff Cmd
+```
+
+**Flat mode:**
+
+```
+Containers (3)
+Components (15)
+References (3)
+ADRs (2)
+```
+
+Click any item to open its `.md` document. Goal shown as tooltip on hover.
+
+## Activation
+
+The extension activates automatically when a workspace contains `.c3/code-map.yaml`.
 
 ## Install
 
@@ -25,19 +83,6 @@ npm run package
 code --install-extension c3-nav.vsix --force
 ```
 
-## Features
-
-| Feature | Description |
-|---------|-------------|
-| **CodeLens** | Inline links above C3 IDs — click to open the architecture doc |
-| **Hover** | Preview frontmatter (id, type, status, refs) on hover |
-| **Go to Definition** | Ctrl+Click on any C3 ID to jump to its `.c3/` document |
-| **Path Navigation** | Click file paths in `code-map.yaml` to open the source file |
-
-## Activation
-
-The extension activates automatically when a workspace contains `.c3/code-map.yaml`.
-
 ## Version
 
-Managed independently in `package.json` (currently `0.1.0`).
+Managed independently in `package.json` (currently `0.3.0`).

--- a/vscode-c3-nav/package-lock.json
+++ b/vscode-c3-nav/package-lock.json
@@ -12,7 +12,8 @@
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.85.0",
         "@vscode/vsce": "^3.0.0",
-        "typescript": "^5.3.0"
+        "typescript": "^5.3.0",
+        "vitest": "^4.0.18"
       },
       "engines": {
         "vscode": "^1.85.0"
@@ -229,6 +230,448 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
@@ -238,6 +681,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -276,6 +726,356 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@secretlint/config-creator": {
       "version": "10.2.2",
@@ -464,6 +1264,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@textlint/ast-node-types": {
       "version": "15.5.2",
       "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.5.2.tgz",
@@ -548,6 +1355,31 @@
         "@textlint/ast-node-types": "15.5.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
@@ -592,6 +1424,117 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vscode/vsce": {
@@ -865,6 +1808,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -1077,6 +2030,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1542,6 +2505,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1571,6 +2541,58 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -1580,6 +2602,16 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1711,6 +2743,21 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -2438,6 +3485,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/markdown-it": {
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
@@ -2603,6 +3660,25 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -2707,6 +3783,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -2899,6 +3986,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -2934,6 +4028,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prebuild-install": {
@@ -3135,6 +4258,51 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-applescript": {
@@ -3346,6 +4514,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -3439,6 +4614,16 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -3474,6 +4659,20 @@
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -3703,6 +4902,81 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -3899,6 +5173,203 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -3937,6 +5408,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/vscode-c3-nav/package.json
+++ b/vscode-c3-nav/package.json
@@ -1,8 +1,8 @@
 {
   "name": "c3-nav",
   "displayName": "C3 Architecture Navigator",
-  "description": "Navigate C3 architecture documents from code-map.yaml and other .c3/ YAML files",
-  "version": "0.1.0",
+  "description": "Navigate C3 architecture documents — cross-reference links, hover previews, and tree view for .c3/ files",
+  "version": "0.3.0",
   "publisher": "lagz0ne",
   "license": "MIT",
   "repository": {
@@ -12,29 +12,99 @@
   "engines": {
     "vscode": "^1.85.0"
   },
-  "categories": ["Other"],
+  "categories": [
+    "Other"
+  ],
   "activationEvents": [
     "workspaceContains:.c3/code-map.yaml"
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "views": {
+      "explorer": [
+        {
+          "id": "c3Navigator",
+          "name": "C3 Architecture",
+          "when": "c3Nav.hasC3Folder"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "c3Nav.openDocument",
         "title": "C3: Open Architecture Document"
+      },
+      {
+        "command": "c3Nav.revealPath",
+        "title": "C3: Reveal Path"
+      },
+      {
+        "command": "c3Nav.toggleViewMode",
+        "title": "C3: Toggle Hierarchy/Flat View",
+        "icon": "$(list-tree)"
+      },
+      {
+        "command": "c3Nav.showDependencies",
+        "title": "Show Dependencies"
+      },
+      {
+        "command": "c3Nav.showDependents",
+        "title": "Show Dependents"
+      },
+      {
+        "command": "c3Nav.openInCodeMap",
+        "title": "Open in Code Map"
+      },
+      {
+        "command": "c3Nav.copyId",
+        "title": "Copy ID"
       }
-    ]
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "c3Nav.toggleViewMode",
+          "when": "view == c3Navigator",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "c3Nav.showDependencies",
+          "when": "view == c3Navigator && viewItem =~ /component|container/",
+          "group": "c3nav@1"
+        },
+        {
+          "command": "c3Nav.showDependents",
+          "when": "view == c3Navigator && viewItem =~ /component|ref/",
+          "group": "c3nav@2"
+        },
+        {
+          "command": "c3Nav.openInCodeMap",
+          "when": "view == c3Navigator && viewItem =~ /component|container|ref/",
+          "group": "c3nav@3"
+        },
+        {
+          "command": "c3Nav.copyId",
+          "when": "view == c3Navigator && viewItem != group && viewItem != category",
+          "group": "c3nav@4"
+        }
+      ]
+    }
   },
   "scripts": {
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "package": "vsce package --out c3-nav.vsix",
     "prepackage": "npm run compile"
   },
   "devDependencies": {
-    "@types/vscode": "^1.85.0",
     "@types/node": "^20.0.0",
+    "@types/vscode": "^1.85.0",
+    "@vscode/vsce": "^3.0.0",
     "typescript": "^5.3.0",
-    "@vscode/vsce": "^3.0.0"
+    "vitest": "^4.0.18"
   }
 }

--- a/vscode-c3-nav/src/__tests__/utils.test.ts
+++ b/vscode-c3-nav/src/__tests__/utils.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { extractIdFromFilename, stripGlobSuffix, parseFrontmatter, isInFrontmatter, isMarkdownTableRow, getBacktickPathAtPosition } from "../utils";
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+
+describe("extractIdFromFilename", () => {
+  it("extracts c3 ID from component filename", () => {
+    expect(extractIdFromFilename("c3-113-check-cmd.md")).toBe("c3-113");
+  });
+
+  it("extracts ref ID from ref filename", () => {
+    expect(extractIdFromFilename("ref-frontmatter-docs.md")).toBe("ref-frontmatter-docs");
+  });
+
+  it("returns undefined for README.md", () => {
+    expect(extractIdFromFilename("README.md")).toBeUndefined();
+  });
+
+  it("extracts ADR ID from filename", () => {
+    expect(extractIdFromFilename("adr-00000000-c3-adoption.md")).toBe("adr-00000000-c3-adoption");
+  });
+
+  it("extracts ADR ID with date prefix", () => {
+    expect(extractIdFromFilename("adr-20260309-add-diff-cmd.md")).toBe("adr-20260309-add-diff-cmd");
+  });
+});
+
+describe("stripGlobSuffix", () => {
+  it("strips /** suffix", () => {
+    expect(stripGlobSuffix("backend/app/**")).toBe("backend/app");
+  });
+
+  it("keeps non-glob paths", () => {
+    expect(stripGlobSuffix("cli/main.go")).toBe("cli/main.go");
+  });
+});
+
+describe("parseFrontmatter", () => {
+  const tmpDir = join(__dirname, "__tmp__");
+  beforeEach(() => mkdirSync(tmpDir, { recursive: true }));
+  afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+  it("parses component frontmatter with all fields", () => {
+    const file = join(tmpDir, "c3-113-check-cmd.md");
+    writeFileSync(file, `---
+id: c3-113
+title: check-cmd
+type: component
+category: feature
+parent: c3-1
+goal: Validate docs
+status: active
+uses: [c3-101, c3-102, c3-104]
+---
+# check-cmd`);
+
+    const result = parseFrontmatter(file);
+    expect(result.title).toBe("check-cmd");
+    expect(result.type).toBe("component");
+    expect(result.category).toBe("feature");
+    expect(result.parent).toBe("c3-1");
+    expect(result.status).toBe("active");
+    expect(result.uses).toEqual(["c3-101", "c3-102", "c3-104"]);
+  });
+
+  it("parses ref frontmatter with via field", () => {
+    const file = join(tmpDir, "ref-test.md");
+    writeFileSync(file, `---
+id: ref-test
+title: Test Ref
+type: ref
+goal: A test ref
+via: [c3-101, c3-103]
+---
+# Test`);
+
+    const result = parseFrontmatter(file);
+    expect(result.type).toBe("ref");
+    expect(result.via).toEqual(["c3-101", "c3-103"]);
+    expect(result.uses).toBeUndefined();
+  });
+
+  it("parses ADR frontmatter", () => {
+    const file = join(tmpDir, "adr-test.md");
+    writeFileSync(file, `---
+id: adr-00000000-c3-adoption
+title: C3 Adoption
+type: adr
+status: in-progress
+---
+# ADR`);
+
+    const result = parseFrontmatter(file);
+    expect(result.type).toBe("adr");
+    expect(result.status).toBe("in-progress");
+  });
+
+  it("defaults status to active when not specified", () => {
+    const file = join(tmpDir, "c3-101.md");
+    writeFileSync(file, `---
+id: c3-101
+title: Frontmatter
+type: component
+category: foundation
+parent: c3-1
+goal: Parse frontmatter
+---`);
+
+    const result = parseFrontmatter(file);
+    expect(result.status).toBe("active");
+  });
+});
+
+describe("isInFrontmatter", () => {
+  const lines = [
+    "---",           // 0
+    "id: c3-113",    // 1
+    "parent: c3-1",  // 2
+    "uses: [c3-101]",// 3
+    "---",           // 4
+    "",              // 5
+    "# Title",       // 6
+    "Body text c3-101", // 7
+  ];
+
+  it("returns true for lines inside frontmatter", () => {
+    expect(isInFrontmatter(lines, 1)).toBe(true);
+    expect(isInFrontmatter(lines, 2)).toBe(true);
+    expect(isInFrontmatter(lines, 3)).toBe(true);
+  });
+
+  it("returns false for frontmatter delimiters", () => {
+    expect(isInFrontmatter(lines, 0)).toBe(false);
+    expect(isInFrontmatter(lines, 4)).toBe(false);
+  });
+
+  it("returns false for lines outside frontmatter", () => {
+    expect(isInFrontmatter(lines, 5)).toBe(false);
+    expect(isInFrontmatter(lines, 6)).toBe(false);
+    expect(isInFrontmatter(lines, 7)).toBe(false);
+  });
+});
+
+describe("isMarkdownTableRow", () => {
+  it("matches table data rows", () => {
+    expect(isMarkdownTableRow("| IN (uses) | Entity graph | c3-102 |")).toBe(true);
+  });
+
+  it("does not match separator rows", () => {
+    expect(isMarkdownTableRow("|-----------|------|---------|")).toBe(false);
+  });
+
+  it("does not match non-table lines", () => {
+    expect(isMarkdownTableRow("Some text mentioning c3-101")).toBe(false);
+  });
+});
+
+describe("getBacktickPathAtPosition", () => {
+  it("extracts path from backtick-wrapped text", () => {
+    const line = "| `cli/internal/frontmatter/parse.go` | Parses YAML |";
+    const result = getBacktickPathAtPosition(line, 10);
+    expect(result).toBeDefined();
+    expect(result!.rawPath).toBe("cli/internal/frontmatter/parse.go");
+    expect(result!.folderPath).toBe("cli/internal/frontmatter/parse.go");
+  });
+
+  it("returns undefined when position is outside backticks", () => {
+    const line = "| `cli/main.go` | Main entry |";
+    const result = getBacktickPathAtPosition(line, 25);
+    expect(result).toBeUndefined();
+  });
+
+  it("strips glob suffix from backtick paths", () => {
+    const line = "Maps to `backend-core/app/**` for coverage";
+    const result = getBacktickPathAtPosition(line, 15);
+    expect(result!.rawPath).toBe("backend-core/app/**");
+    expect(result!.folderPath).toBe("backend-core/app");
+  });
+});

--- a/vscode-c3-nav/src/codeLensProvider.ts
+++ b/vscode-c3-nav/src/codeLensProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import { DocMap } from "./docMap";
-import { C3_ID_PATTERN, getPathAtPosition } from "./utils";
+import { C3_ID_PATTERN, findFirstPathOnLine, isInFrontmatter, isMarkdownTableRow, getBacktickPathAtPosition } from "./utils";
 
 export class C3CodeLensProvider implements vscode.CodeLensProvider {
   private _onDidChangeCodeLenses = new vscode.EventEmitter<void>();
@@ -15,45 +15,71 @@ export class C3CodeLensProvider implements vscode.CodeLensProvider {
 
   provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
     const lenses: vscode.CodeLens[] = [];
+    const isMarkdown = document.languageId === "markdown";
+    const allLines = isMarkdown
+      ? Array.from({ length: document.lineCount }, (_, i) => document.lineAt(i).text)
+      : [];
 
     for (let i = 0; i < document.lineCount; i++) {
       const line = document.lineAt(i);
+      const showStructuredLens = !isMarkdown || isInFrontmatter(allLines, i) || isMarkdownTableRow(line.text);
 
-      // C3 ID lenses
-      const regex = new RegExp(C3_ID_PATTERN.source, "g");
-      let match: RegExpExecArray | null;
+      // C3 ID lenses (frontmatter + tables in markdown, everywhere in YAML)
+      if (showStructuredLens) {
+        const regex = new RegExp(C3_ID_PATTERN.source, "g");
+        let match: RegExpExecArray | null;
 
-      while ((match = regex.exec(line.text)) !== null) {
-        const id = match[0];
-        const entry = this.docMap.get(id);
-        if (!entry) {
-          continue;
+        while ((match = regex.exec(line.text)) !== null) {
+          const id = match[0];
+          const entry = this.docMap.get(id);
+          if (!entry) {
+            continue;
+          }
+
+          const range = new vscode.Range(i, match.index, i, match.index + id.length);
+          const filename = path.basename(entry.path);
+          const title = entry.title ? `${entry.title} (${filename})` : filename;
+
+          lenses.push(
+            new vscode.CodeLens(range, {
+              title: `→ ${title}`,
+              command: "c3Nav.openDocument",
+              arguments: [entry.path],
+            })
+          );
         }
-
-        const range = new vscode.Range(i, match.index, i, match.index + id.length);
-        const filename = path.basename(entry.path);
-        const title = entry.title ? `${entry.title} (${filename})` : filename;
-
-        lenses.push(
-          new vscode.CodeLens(range, {
-            title: `→ ${title}`,
-            command: "c3Nav.openDocument",
-            arguments: [entry.path],
-          })
-        );
       }
 
-      // Path lenses (for quoted glob paths like "backend-core/app/sysadmin/**")
-      const pathMatch = getPathAtPosition(line.text, line.text.indexOf('"') + 1);
-      if (pathMatch) {
-        const range = new vscode.Range(i, pathMatch.start, i, pathMatch.end);
-        lenses.push(
-          new vscode.CodeLens(range, {
-            title: `→ Open: ${pathMatch.folderPath}`,
-            command: "c3Nav.revealPath",
-            arguments: [pathMatch.folderPath],
-          })
-        );
+      // Path lenses — YAML: quoted paths, Markdown: backtick paths in structured areas
+      if (isMarkdown) {
+        if (showStructuredLens) {
+          const backtickIdx = line.text.indexOf("`");
+          if (backtickIdx >= 0) {
+            const pathMatch = getBacktickPathAtPosition(line.text, backtickIdx + 1);
+            if (pathMatch) {
+              const range = new vscode.Range(i, pathMatch.start, i, pathMatch.end);
+              lenses.push(
+                new vscode.CodeLens(range, {
+                  title: `→ Open: ${pathMatch.folderPath}`,
+                  command: "c3Nav.revealPath",
+                  arguments: [pathMatch.folderPath],
+                })
+              );
+            }
+          }
+        }
+      } else {
+        const pathMatch = findFirstPathOnLine(line.text);
+        if (pathMatch) {
+          const range = new vscode.Range(i, pathMatch.start, i, pathMatch.end);
+          lenses.push(
+            new vscode.CodeLens(range, {
+              title: `→ Open: ${pathMatch.folderPath}`,
+              command: "c3Nav.revealPath",
+              arguments: [pathMatch.folderPath],
+            })
+          );
+        }
       }
     }
 

--- a/vscode-c3-nav/src/definitionProvider.ts
+++ b/vscode-c3-nav/src/definitionProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import { DocMap } from "./docMap";
-import { getIdAtPosition, getPathAtPosition } from "./utils";
+import { getIdAtPosition, getPathAtPosition, getBacktickPathAtPosition } from "./utils";
 
 export class C3DefinitionProvider implements vscode.DefinitionProvider {
   constructor(private docMap: DocMap) {}
@@ -27,6 +27,16 @@ export class C3DefinitionProvider implements vscode.DefinitionProvider {
       const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
       if (workspaceFolder) {
         const absPath = path.join(workspaceFolder.uri.fsPath, pathMatch.folderPath);
+        return new vscode.Location(vscode.Uri.file(absPath), new vscode.Position(0, 0));
+      }
+    }
+
+    // Try backtick path (markdown files)
+    const backtickMatch = getBacktickPathAtPosition(line, position.character);
+    if (backtickMatch) {
+      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+      if (workspaceFolder) {
+        const absPath = path.join(workspaceFolder.uri.fsPath, backtickMatch.folderPath);
         return new vscode.Location(vscode.Uri.file(absPath), new vscode.Position(0, 0));
       }
     }

--- a/vscode-c3-nav/src/docMap.ts
+++ b/vscode-c3-nav/src/docMap.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import * as path from "path";
+import * as fs from "fs";
 import { DocEntry, extractIdFromFilename, parseFrontmatter } from "./utils";
 
 export class DocMap {
@@ -17,7 +18,23 @@ export class DocMap {
 
     for (const file of files) {
       const filename = path.basename(file.fsPath);
-      const id = extractIdFromFilename(filename);
+      let id = extractIdFromFilename(filename);
+
+      // README.md files store their ID in frontmatter (containers like c3-0, c3-1, c3-2)
+      if (!id && filename === "README.md") {
+        const frontmatter = parseFrontmatter(file.fsPath);
+        id = this.readFrontmatterId(file.fsPath);
+        if (!id) {
+          continue;
+        }
+        if (this.map.has(id)) {
+          console.warn(`[C3 Nav] Duplicate ID "${id}" — keeping first match, skipping ${file.fsPath}`);
+          continue;
+        }
+        this.map.set(id, { path: file.fsPath, ...frontmatter });
+        continue;
+      }
+
       if (!id) {
         continue;
       }
@@ -28,10 +45,7 @@ export class DocMap {
       }
 
       const frontmatter = parseFrontmatter(file.fsPath);
-      this.map.set(id, {
-        path: file.fsPath,
-        ...frontmatter,
-      });
+      this.map.set(id, { path: file.fsPath, ...frontmatter });
     }
 
     console.log(`[C3 Nav] Built document map with ${this.map.size} entries`);
@@ -40,6 +54,10 @@ export class DocMap {
 
   get(id: string): DocEntry | undefined {
     return this.map.get(id);
+  }
+
+  size(): number {
+    return this.map.size;
   }
 
   entries(): IterableIterator<[string, DocEntry]> {
@@ -57,6 +75,21 @@ export class DocMap {
     this.watcher.onDidChange(rebuild);
 
     return this.watcher;
+  }
+
+  private readFrontmatterId(filePath: string): string | undefined {
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, "utf-8");
+    } catch {
+      return undefined;
+    }
+    const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!fmMatch) {
+      return undefined;
+    }
+    const idMatch = fmMatch[1].match(/^id:\s*(.+)$/m);
+    return idMatch ? idMatch[1].trim() : undefined;
   }
 
   dispose(): void {

--- a/vscode-c3-nav/src/extension.ts
+++ b/vscode-c3-nav/src/extension.ts
@@ -5,10 +5,17 @@ import { DocMap } from "./docMap";
 import { C3CodeLensProvider } from "./codeLensProvider";
 import { C3DefinitionProvider } from "./definitionProvider";
 import { C3HoverProvider } from "./hoverProvider";
+import { C3TreeViewProvider } from "./treeViewProvider";
+import { registerTreeCommands } from "./treeCommands";
 
 const YAML_IN_C3: vscode.DocumentSelector = {
   scheme: "file",
   pattern: "**/.c3/**/*.yaml",
+};
+
+const MD_IN_C3: vscode.DocumentSelector = {
+  scheme: "file",
+  pattern: "**/.c3/**/*.md",
 };
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
@@ -17,19 +24,43 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     return;
   }
 
+  // Set context for conditional view visibility
+  vscode.commands.executeCommand("setContext", "c3Nav.hasC3Folder", true);
+
   const docMap = new DocMap();
   await docMap.build(workspaceFolder);
 
+  // CodeLens
   const codeLensProvider = new C3CodeLensProvider(docMap);
-
-  // Refresh CodeLens after doc map rebuilds (single watcher, no race condition)
   docMap.onDidRebuild(() => codeLensProvider.refresh());
 
+  // Tree View
+  const treeViewProvider = new C3TreeViewProvider(docMap);
+  docMap.onDidRebuild(() => treeViewProvider.refresh());
+
   context.subscriptions.push(
+    // File watching
     docMap.startWatching(workspaceFolder),
+
+    // CodeLens for YAML and Markdown
     vscode.languages.registerCodeLensProvider(YAML_IN_C3, codeLensProvider),
+    vscode.languages.registerCodeLensProvider(MD_IN_C3, codeLensProvider),
+
+    // Definition for YAML and Markdown
     vscode.languages.registerDefinitionProvider(YAML_IN_C3, new C3DefinitionProvider(docMap)),
+    vscode.languages.registerDefinitionProvider(MD_IN_C3, new C3DefinitionProvider(docMap)),
+
+    // Hover for YAML and Markdown
     vscode.languages.registerHoverProvider(YAML_IN_C3, new C3HoverProvider(docMap)),
+    vscode.languages.registerHoverProvider(MD_IN_C3, new C3HoverProvider(docMap)),
+
+    // Tree view
+    vscode.window.createTreeView("c3Navigator", {
+      treeDataProvider: treeViewProvider,
+      showCollapseAll: true,
+    }),
+
+    // Commands
     vscode.commands.registerCommand("c3Nav.openDocument", (filePath: string) => {
       const uri = vscode.Uri.file(filePath);
       vscode.window.showTextDocument(uri, { preview: true });
@@ -39,7 +70,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       const uri = vscode.Uri.file(absPath);
 
       if (fs.existsSync(absPath) && fs.statSync(absPath).isDirectory()) {
-        // Reveal in explorer, then expand the folder
         await vscode.commands.executeCommand("revealInExplorer", uri);
         await vscode.commands.executeCommand("list.expand");
       } else if (fs.existsSync(absPath)) {
@@ -47,10 +77,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       } else {
         vscode.window.showWarningMessage(`Path not found: ${relativePath}`);
       }
+    }),
+    vscode.commands.registerCommand("c3Nav.toggleViewMode", () => {
+      treeViewProvider.toggleViewMode();
     })
   );
 
-  console.log("[C3 Nav] Extension activated");
+  // Register tree context menu commands
+  registerTreeCommands(context, docMap, workspaceFolder);
+
 }
 
 export function deactivate(): void {

--- a/vscode-c3-nav/src/hoverProvider.ts
+++ b/vscode-c3-nav/src/hoverProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
 import { DocMap } from "./docMap";
-import { getIdAtPosition, getPathAtPosition } from "./utils";
+import { getIdAtPosition, getPathAtPosition, getBacktickPathAtPosition } from "./utils";
 
 export class C3HoverProvider implements vscode.HoverProvider {
   constructor(private docMap: DocMap) {}
@@ -18,22 +18,29 @@ export class C3HoverProvider implements vscode.HoverProvider {
     if (idMatch) {
       const entry = this.docMap.get(idMatch.id);
       if (entry) {
-        return this.buildDocHover(idMatch, entry);
+        return this.buildDocHover(position.line, idMatch, entry);
       }
     }
 
     // Try quoted path
     const pathMatch = getPathAtPosition(line, position.character);
     if (pathMatch) {
-      return this.buildPathHover(pathMatch);
+      return this.buildPathHover(position.line, pathMatch);
+    }
+
+    // Try backtick path (markdown files)
+    const backtickMatch = getBacktickPathAtPosition(line, position.character);
+    if (backtickMatch) {
+      return this.buildPathHover(position.line, backtickMatch);
     }
 
     return undefined;
   }
 
   private buildDocHover(
+    lineNumber: number,
     match: { id: string; start: number; end: number },
-    entry: { path: string; title?: string; goal?: string; summary?: string }
+    entry: { path: string; title?: string; goal?: string; summary?: string; status?: string }
   ): vscode.Hover {
     const md = new vscode.MarkdownString("", true);
     md.isTrusted = true;
@@ -48,6 +55,10 @@ export class C3HoverProvider implements vscode.HoverProvider {
       md.appendMarkdown(`*Goal:* ${entry.goal}\n\n`);
     }
 
+    if (entry.status && entry.status !== "active") {
+      md.appendMarkdown(`*Status:* \`${entry.status}\`\n\n`);
+    }
+
     if (entry.summary) {
       md.appendMarkdown(`*Summary:* ${entry.summary}\n\n`);
     }
@@ -55,11 +66,12 @@ export class C3HoverProvider implements vscode.HoverProvider {
     const fileUri = vscode.Uri.file(entry.path);
     md.appendMarkdown(`[Open document](${fileUri})`);
 
-    const range = new vscode.Range(match.start, match.start, match.start, match.end);
+    const range = new vscode.Range(lineNumber, match.start, lineNumber, match.end);
     return new vscode.Hover(md, range);
   }
 
   private buildPathHover(
+    lineNumber: number,
     match: { rawPath: string; folderPath: string; start: number; end: number }
   ): vscode.Hover | undefined {
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
@@ -83,7 +95,7 @@ export class C3HoverProvider implements vscode.HoverProvider {
       md.appendMarkdown(`*File* — [Open](command:c3Nav.revealPath?${encodeURIComponent(JSON.stringify(match.folderPath))})\n\n`);
     }
 
-    const range = new vscode.Range(0, match.start, 0, match.end);
+    const range = new vscode.Range(lineNumber, match.start, lineNumber, match.end);
     return new vscode.Hover(md, range);
   }
 }

--- a/vscode-c3-nav/src/treeCommands.ts
+++ b/vscode-c3-nav/src/treeCommands.ts
@@ -1,0 +1,88 @@
+import * as vscode from "vscode";
+import * as path from "path";
+import { DocMap } from "./docMap";
+
+export function registerTreeCommands(
+  context: vscode.ExtensionContext,
+  docMap: DocMap,
+  workspaceFolder: vscode.WorkspaceFolder
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand("c3Nav.showDependencies", async (id: string) => {
+      const entry = docMap.get(id);
+      if (!entry?.uses || entry.uses.length === 0) {
+        vscode.window.showInformationMessage(`${id} has no dependencies.`);
+        return;
+      }
+
+      const items = entry.uses
+        .map((depId) => {
+          const dep = docMap.get(depId);
+          return {
+            label: depId,
+            description: dep?.title,
+            detail: dep?.goal,
+            depPath: dep?.path,
+          };
+        })
+        .filter((item) => item.depPath);
+
+      const selected = await vscode.window.showQuickPick(items, {
+        placeHolder: `Dependencies of ${id}`,
+      });
+
+      if (selected?.depPath) {
+        vscode.window.showTextDocument(vscode.Uri.file(selected.depPath), { preview: true });
+      }
+    }),
+
+    vscode.commands.registerCommand("c3Nav.showDependents", async (id: string) => {
+      const dependents: Array<{ id: string; title?: string; path: string }> = [];
+
+      for (const [entryId, entry] of docMap.entries()) {
+        if (entry.uses?.includes(id) || entry.via?.includes(id)) {
+          dependents.push({ id: entryId, title: entry.title, path: entry.path });
+        }
+      }
+
+      if (dependents.length === 0) {
+        vscode.window.showInformationMessage(`No components depend on ${id}.`);
+        return;
+      }
+
+      const items = dependents.map((dep) => ({
+        label: dep.id,
+        description: dep.title,
+        depPath: dep.path,
+      }));
+
+      const selected = await vscode.window.showQuickPick(items, {
+        placeHolder: `Dependents of ${id}`,
+      });
+
+      if (selected?.depPath) {
+        vscode.window.showTextDocument(vscode.Uri.file(selected.depPath), { preview: true });
+      }
+    }),
+
+    vscode.commands.registerCommand("c3Nav.openInCodeMap", async (id: string) => {
+      const codeMapPath = path.join(workspaceFolder.uri.fsPath, ".c3", "code-map.yaml");
+      const doc = await vscode.workspace.openTextDocument(codeMapPath);
+      const editor = await vscode.window.showTextDocument(doc, { preview: true });
+
+      for (let i = 0; i < doc.lineCount; i++) {
+        if (doc.lineAt(i).text.includes(id)) {
+          const range = new vscode.Range(i, 0, i, 0);
+          editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+          editor.selection = new vscode.Selection(range.start, range.start);
+          break;
+        }
+      }
+    }),
+
+    vscode.commands.registerCommand("c3Nav.copyId", (id: string) => {
+      vscode.env.clipboard.writeText(id);
+      vscode.window.showInformationMessage(`Copied: ${id}`);
+    })
+  );
+}

--- a/vscode-c3-nav/src/treeViewProvider.ts
+++ b/vscode-c3-nav/src/treeViewProvider.ts
@@ -1,0 +1,218 @@
+import * as vscode from "vscode";
+import { DocMap } from "./docMap";
+
+type ViewMode = "hierarchy" | "flat";
+
+export class C3TreeViewProvider implements vscode.TreeDataProvider<string> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<string | undefined>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  private viewMode: ViewMode = "hierarchy";
+
+  constructor(private docMap: DocMap) {}
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
+  toggleViewMode(): void {
+    this.viewMode = this.viewMode === "hierarchy" ? "flat" : "hierarchy";
+    this.refresh();
+  }
+
+  getViewMode(): ViewMode {
+    return this.viewMode;
+  }
+
+  getTreeItem(element: string): vscode.TreeItem {
+    // Group headers (non-ID nodes)
+    if (element.startsWith("__group:")) {
+      const label = element.replace("__group:", "");
+      const item = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.Expanded);
+      item.contextValue = "group";
+      return item;
+    }
+
+    // Category sub-headers
+    if (element.startsWith("__category:")) {
+      const parts = element.replace("__category:", "").split(":");
+      const label = parts[1].charAt(0).toUpperCase() + parts[1].slice(1);
+      const item = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.Expanded);
+      item.contextValue = "category";
+      return item;
+    }
+
+    const entry = this.docMap.get(element);
+    if (!entry) {
+      return new vscode.TreeItem(element);
+    }
+
+    const hasChildren = this.getChildIds(element).length > 0;
+    const collapsible = hasChildren
+      ? vscode.TreeItemCollapsibleState.Expanded
+      : vscode.TreeItemCollapsibleState.None;
+
+    const label = entry.title ? `${element} · ${entry.title}` : element;
+    const item = new vscode.TreeItem(label, collapsible);
+
+    // Status badge
+    if (entry.status && entry.status !== "active") {
+      item.description = `[${entry.status}]`;
+    }
+
+    // Goal as tooltip
+    if (entry.goal) {
+      item.tooltip = entry.goal;
+    }
+
+    // Click opens the document
+    item.command = {
+      command: "c3Nav.openDocument",
+      title: "Open Document",
+      arguments: [entry.path],
+    };
+
+    item.contextValue = entry.type || "document";
+
+    return item;
+  }
+
+  getChildren(element?: string): string[] {
+    if (!element) {
+      return this.viewMode === "hierarchy" ? this.getHierarchyRoots() : this.getFlatGroups();
+    }
+
+    if (this.viewMode === "flat") {
+      return this.getFlatGroupChildren(element);
+    }
+
+    return this.getHierarchyChildren(element);
+  }
+
+  // --- Hierarchy mode ---
+
+  private getHierarchyRoots(): string[] {
+    const roots: string[] = [];
+
+    // Find root container (c3-0) or containers with no parent
+    for (const [id, entry] of this.docMap.entries()) {
+      if (entry.type === "container" && !entry.parent) {
+        roots.push(id);
+      }
+    }
+
+    // Add References and ADRs groups
+    if (this.hasEntriesOfType("ref")) {
+      roots.push("__group:References");
+    }
+    if (this.hasEntriesOfType("adr")) {
+      roots.push("__group:ADRs");
+    }
+
+    return roots;
+  }
+
+  private getHierarchyChildren(element: string): string[] {
+    if (element.startsWith("__group:")) {
+      const group = element.replace("__group:", "");
+      if (group === "References") {
+        return this.getEntriesOfType("ref");
+      }
+      if (group === "ADRs") {
+        return this.getEntriesOfType("adr");
+      }
+      return [];
+    }
+
+    if (element.startsWith("__category:")) {
+      const parts = element.replace("__category:", "").split(":");
+      const parentId = parts[0];
+      const category = parts[1];
+      return this.getChildIds(parentId).filter((childId) => {
+        const entry = this.docMap.get(childId);
+        return entry?.category === category;
+      });
+    }
+
+    // For containers: group children by category if they have categories
+    const children = this.getChildIds(element);
+    const categories = new Set<string>();
+    for (const childId of children) {
+      const entry = this.docMap.get(childId);
+      if (entry?.category) {
+        categories.add(entry.category);
+      }
+    }
+
+    if (categories.size > 1) {
+      // Group by category
+      return Array.from(categories)
+        .sort()
+        .map((cat) => `__category:${element}:${cat}`);
+    }
+
+    // No categories or single category — list children directly
+    return children;
+  }
+
+  private getChildIds(parentId: string): string[] {
+    const children: string[] = [];
+    for (const [id, entry] of this.docMap.entries()) {
+      if (entry.parent === parentId && entry.type !== "ref" && entry.type !== "adr") {
+        children.push(id);
+      }
+    }
+    return children.sort();
+  }
+
+  // --- Flat mode ---
+
+  private getFlatGroups(): string[] {
+    const groups: string[] = [];
+    if (this.hasEntriesOfType("container")) {
+      groups.push("__group:Containers");
+    }
+    if (this.hasEntriesOfType("component")) {
+      groups.push("__group:Components");
+    }
+    if (this.hasEntriesOfType("ref")) {
+      groups.push("__group:References");
+    }
+    if (this.hasEntriesOfType("adr")) {
+      groups.push("__group:ADRs");
+    }
+    return groups;
+  }
+
+  private getFlatGroupChildren(element: string): string[] {
+    const group = element.replace("__group:", "");
+    const typeMap: Record<string, string> = {
+      Containers: "container",
+      Components: "component",
+      References: "ref",
+      ADRs: "adr",
+    };
+    return this.getEntriesOfType(typeMap[group] || "");
+  }
+
+  // --- Helpers ---
+
+  private hasEntriesOfType(type: string): boolean {
+    for (const [, entry] of this.docMap.entries()) {
+      if (entry.type === type) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private getEntriesOfType(type: string): string[] {
+    const ids: string[] = [];
+    for (const [id, entry] of this.docMap.entries()) {
+      if (entry.type === type) {
+        ids.push(id);
+      }
+    }
+    return ids.sort();
+  }
+}

--- a/vscode-c3-nav/src/utils.ts
+++ b/vscode-c3-nav/src/utils.ts
@@ -1,20 +1,26 @@
 import * as fs from "fs";
 
-/** Matches c3-0 through c3-999 and ref-xxx-yyy patterns */
-export const C3_ID_PATTERN = /\b(c3-\d{1,3}|ref-[a-z][\w-]*)\b/g;
+/** Matches c3-0 through c3-999, ref-xxx-yyy, and adr-xxx-yyy patterns */
+export const C3_ID_PATTERN = /\b(c3-\d{1,3}|ref-[a-z][\w-]*|adr-[\w-]+)\b/g;
 
 export interface DocEntry {
   path: string;
   title?: string;
   goal?: string;
   summary?: string;
+  type?: "container" | "component" | "ref" | "adr";
+  category?: "foundation" | "feature";
+  parent?: string;
+  uses?: string[];
+  via?: string[];
+  status?: string;
 }
 
 /**
  * Parse YAML frontmatter from a markdown file.
  * Extracts title, goal, and summary fields from the --- delimited block.
  */
-export function parseFrontmatter(filePath: string): Pick<DocEntry, "title" | "goal" | "summary"> {
+export function parseFrontmatter(filePath: string): Omit<DocEntry, "path"> {
   let content: string;
   try {
     content = fs.readFileSync(filePath, "utf-8");
@@ -28,7 +34,7 @@ export function parseFrontmatter(filePath: string): Pick<DocEntry, "title" | "go
   }
 
   const fm = fmMatch[1];
-  const result: Pick<DocEntry, "title" | "goal" | "summary"> = {};
+  const result: Omit<DocEntry, "path"> = {};
 
   const titleMatch = fm.match(/^title:\s*(.+)$/m);
   if (titleMatch) {
@@ -43,6 +49,46 @@ export function parseFrontmatter(filePath: string): Pick<DocEntry, "title" | "go
   const summaryMatch = fm.match(/^summary:\s*(.+)$/m);
   if (summaryMatch) {
     result.summary = stripYamlQuotes(summaryMatch[1].trim());
+  }
+
+  const typeMatch = fm.match(/^type:\s*(.+)$/m);
+  if (typeMatch) {
+    result.type = stripYamlQuotes(typeMatch[1].trim()) as DocEntry["type"];
+  }
+
+  const categoryMatch = fm.match(/^category:\s*(.+)$/m);
+  if (categoryMatch) {
+    result.category = stripYamlQuotes(categoryMatch[1].trim()) as DocEntry["category"];
+  }
+
+  const parentMatch = fm.match(/^parent:\s*(.+)$/m);
+  if (parentMatch) {
+    result.parent = stripYamlQuotes(parentMatch[1].trim());
+  }
+
+  const usesMatch = fm.match(/^uses:\s*\[([^\]]*)\]$/m);
+  if (usesMatch) {
+    result.uses = usesMatch[1].split(",").map((s) => s.trim()).filter(Boolean);
+  }
+
+  const viaMatch = fm.match(/^via:\s*\[([^\]]*)\]$/m);
+  if (viaMatch) {
+    result.via = viaMatch[1].split(",").map((s) => s.trim()).filter(Boolean);
+  }
+
+  const statusMatch = fm.match(/^status:\s*(.+)$/m);
+  result.status = statusMatch ? stripYamlQuotes(statusMatch[1].trim()) : "active";
+
+  // Infer type for root docs that lack an explicit type field
+  // c3-0 style root docs have an id but no type — treat as container
+  if (!result.type) {
+    const idMatch = fm.match(/^id:\s*(.+)$/m);
+    if (idMatch) {
+      const id = stripYamlQuotes(idMatch[1].trim());
+      if (/^c3-\d+$/.test(id)) {
+        result.type = "container";
+      }
+    }
   }
 
   return result;
@@ -72,6 +118,11 @@ export function extractIdFromFilename(filename: string): string | undefined {
     return refMatch[1];
   }
 
+  const adrMatch = filename.match(/^(adr-[\w-]+)\.md$/);
+  if (adrMatch) {
+    return adrMatch[1];
+  }
+
   return undefined;
 }
 
@@ -83,7 +134,7 @@ export function getIdAtPosition(
   lineText: string,
   characterPos: number
 ): { id: string; start: number; end: number } | undefined {
-  const regex = /\b(c3-\d{1,3}|ref-[a-z][\w-]*)\b/g;
+  const regex = /\b(c3-\d{1,3}|ref-[a-z][\w-]*|adr-[\w-]+)\b/g;
   let match: RegExpExecArray | null;
 
   while ((match = regex.exec(lineText)) !== null) {
@@ -98,16 +149,21 @@ export function getIdAtPosition(
 }
 
 /** Matches a quoted glob path in a YAML list item, e.g. - "backend-core/app/sysadmin/**" */
-const QUOTED_PATH_PATTERN = /["']([^"']+)["']/g;
+const QUOTED_PATH_PATTERN = /["']([^"']+)["']/;
+
+/** Matches an unquoted YAML list path, e.g. "  - cli/cmd/check_enhanced.go" */
+const YAML_LIST_PATH_PATTERN = /^\s*-\s+(\S+)/;
 
 /**
- * Get the quoted path string at a given position in a line of text.
+ * Get a path string at a given position in a line of text.
+ * Supports both quoted paths ("path/to/file") and unquoted YAML list paths (- path/to/file).
  * Returns the raw path (with glob), the folder path (glob stripped), and positions.
  */
 export function getPathAtPosition(
   lineText: string,
   characterPos: number
 ): { rawPath: string; folderPath: string; start: number; end: number } | undefined {
+  // Try quoted paths first
   const regex = new RegExp(QUOTED_PATH_PATTERN.source, "g");
   let match: RegExpExecArray | null;
 
@@ -122,6 +178,50 @@ export function getPathAtPosition(
     }
   }
 
+  // Try unquoted YAML list paths (e.g., "  - cli/cmd/check_enhanced.go")
+  const listMatch = lineText.match(YAML_LIST_PATH_PATTERN);
+  if (listMatch) {
+    const rawPath = listMatch[1];
+    const start = lineText.indexOf(rawPath);
+    const end = start + rawPath.length;
+    if (characterPos >= start && characterPos <= end) {
+      const folderPath = stripGlobSuffix(rawPath);
+      return { rawPath, folderPath, start, end };
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Find the first navigable path on a line (no position required).
+ * Checks quoted paths first, then unquoted YAML list paths.
+ * Used by CodeLens which needs to find any path on a line.
+ */
+export function findFirstPathOnLine(
+  lineText: string
+): { rawPath: string; folderPath: string; start: number; end: number } | undefined {
+  // Try quoted path
+  const quoteMatch = lineText.match(QUOTED_PATH_PATTERN);
+  if (quoteMatch) {
+    const rawPath = quoteMatch[1];
+    const matchIdx = lineText.indexOf(quoteMatch[0]);
+    const start = matchIdx + 1; // after opening quote
+    const end = start + rawPath.length;
+    const folderPath = stripGlobSuffix(rawPath);
+    return { rawPath, folderPath, start, end };
+  }
+
+  // Try unquoted YAML list path
+  const listMatch = lineText.match(YAML_LIST_PATH_PATTERN);
+  if (listMatch) {
+    const rawPath = listMatch[1];
+    const start = lineText.indexOf(rawPath);
+    const end = start + rawPath.length;
+    const folderPath = stripGlobSuffix(rawPath);
+    return { rawPath, folderPath, start, end };
+  }
+
   return undefined;
 }
 
@@ -132,4 +232,63 @@ export function getPathAtPosition(
  */
 export function stripGlobSuffix(globPath: string): string {
   return globPath.replace(/\/\*\*$/, "").replace(/\/\*\.[a-z]+$/, "");
+}
+
+/**
+ * Check if a line index is inside the YAML frontmatter block.
+ * Frontmatter is between the first `---` (line 0) and the next `---`.
+ * Returns true for content lines, false for delimiters and outside.
+ */
+export function isInFrontmatter(lines: string[], lineIndex: number): boolean {
+  if (lines[0] !== "---") {
+    return false;
+  }
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === "---") {
+      return lineIndex > 0 && lineIndex < i;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check if a line is a markdown table data row (not a separator row).
+ * Table rows start and end with | and contain non-dash content.
+ */
+export function isMarkdownTableRow(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("|") || !trimmed.endsWith("|")) {
+    return false;
+  }
+  // Separator rows contain only |, -, :, and spaces
+  return !/^\|[\s|:-]+\|$/.test(trimmed);
+}
+
+/**
+ * Get a backtick-wrapped file path at a given position in a line.
+ * Matches patterns like `cli/internal/frontmatter/parse.go`.
+ * Returns path info with glob suffix stripped for navigation.
+ */
+export function getBacktickPathAtPosition(
+  lineText: string,
+  characterPos: number
+): { rawPath: string; folderPath: string; start: number; end: number } | undefined {
+  const regex = /`([^`]+\.[a-z]+[^`]*)`|`([^`]+\/[^`]+)`/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(lineText)) !== null) {
+    const pathValue = match[1] || match[2];
+    const start = match.index + 1; // after opening backtick
+    const end = start + pathValue.length;
+    if (characterPos >= start && characterPos <= end) {
+      return {
+        rawPath: pathValue,
+        folderPath: stripGlobSuffix(pathValue),
+        start,
+        end,
+      };
+    }
+  }
+
+  return undefined;
 }

--- a/vscode-c3-nav/tsconfig.json
+++ b/vscode-c3-nav/tsconfig.json
@@ -11,5 +11,5 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "exclude": ["node_modules", "out"]
+  "exclude": ["node_modules", "out", "src/__tests__"]
 }


### PR DESCRIPTION
## Summary

- **Markdown navigation** — CodeLens, hover, and Ctrl+Click for C3 IDs and file paths in `.c3/**/*.md` files (frontmatter + tables)
- **Tree view sidebar** — C3 Architecture panel in Explorer with hierarchy/flat toggle, status badges, goal tooltips, and context menu actions (Show Dependencies, Show Dependents, Open in Code Map, Copy ID)
- **Bug fixes** — Fix CodeLens crash from global regex flag on `.match()`, fix hover range using char offset as line number, infer `type=container` for root docs missing explicit type, add unquoted YAML path support for code-map.yaml

### Tree View (hierarchy mode)

```
c3-0 · C3 Design
├── c3-1 · Go CLI
│   ├── Foundation
│   │   ├── c3-101 · Frontmatter Parser
│   │   ├── c3-102 · Walker
│   │   └── ...
│   └── Feature
│       ├── c3-110 · Init Cmd
│       └── ...
├── c3-2 · Claude Skill
├── References
└── ADRs
```

## Test plan

- [ ] Open `.c3/code-map.yaml` — verify CodeLens appears on every C3 ID line and every path line
- [ ] Hover over `c3-101` in code-map.yaml — verify tooltip shows title, goal, summary
- [ ] Ctrl+Click on `c3-113` — verify it opens the `.md` document
- [ ] Click a path like `cli/cmd/check_enhanced.go` — verify it opens the file
- [ ] Open a `.c3/*.md` file — verify CodeLens in frontmatter and tables, hover everywhere
- [ ] Check C3 Architecture panel in Explorer sidebar — verify hierarchy with c3-0 as root
- [ ] Toggle flat view — verify four groups (Containers, Components, References, ADRs)
- [ ] Right-click a component in tree — verify context menu actions work