### PR TITLE
fix(impact): add --include-code to surface undocumented callers

### DIFF
--- a/cli/cmd/adr.go
+++ b/cli/cmd/adr.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/lagz0ne/c3-design/cli/internal/numbering"
+	"github.com/lagz0ne/c3-design/cli/internal/store"
+)
+
+// AdrFromDiffOptions holds parameters for `c3x adr --from-diff`.
+type AdrFromDiffOptions struct {
+	Store      *store.Store
+	C3Dir      string
+	ProjectDir string
+	Slug       string
+	Since      string
+}
+
+// RunAdrFromDiff prints an ADR scaffold to w, pre-populating affects: and a
+// Context section listing touched files grouped by owning component.
+// Output is markdown (frontmatter + body) — user pipes to `c3x add adr`
+// or edits and saves. Never writes to .c3/ directly.
+func RunAdrFromDiff(opts AdrFromDiffOptions, w io.Writer) error {
+	slug := opts.Slug
+	if slug == "" {
+		slug = "from-diff"
+	}
+
+	files, err := gitTouchedFiles(opts.ProjectDir, opts.Since)
+	if err != nil {
+		return fmt.Errorf("git: %w", err)
+	}
+
+	// Group touched source files by owning component. Canonical .c3/ edits
+	// contribute their entity directly.
+	componentFiles := map[string][]string{}
+	affectedParents := map[string]bool{}
+	for _, f := range files {
+		ids, _ := opts.Store.LookupByFile(f)
+		if len(ids) == 0 {
+			componentFiles[""] = append(componentFiles[""], f)
+			continue
+		}
+		for _, id := range ids {
+			componentFiles[id] = append(componentFiles[id], f)
+			if e, err := opts.Store.GetEntity(id); err == nil && e.ParentID != "" {
+				affectedParents[e.ParentID] = true
+			}
+		}
+	}
+
+	var parents []string
+	for p := range affectedParents {
+		parents = append(parents, p)
+	}
+	sort.Strings(parents)
+
+	var componentIDs []string
+	for id := range componentFiles {
+		if id != "" {
+			componentIDs = append(componentIDs, id)
+		}
+	}
+	sort.Strings(componentIDs)
+
+	id := numbering.NextAdrId(slug)
+	date := strings.TrimPrefix(id, "adr-")
+	date = strings.SplitN(date, "-", 2)[0]
+	title := humanizeSlug(slug)
+
+	fmt.Fprintf(w, "---\nid: %s\ntitle: %s\ntype: adr\nstatus: proposed\ndate: %q\naffects: %s\n---\n\n",
+		id, title, date, yamlIDList(parents))
+	fmt.Fprintf(w, "# %s\n\n", title)
+
+	fmt.Fprintln(w, "## Context")
+	fmt.Fprintln(w)
+	if len(files) == 0 {
+		fmt.Fprintln(w, "No touched files detected.")
+	} else {
+		fmt.Fprintf(w, "Touches %d file(s) across %d component(s):\n\n", len(files), len(componentIDs))
+		for _, id := range componentIDs {
+			e, _ := opts.Store.GetEntity(id)
+			titleStr := id
+			if e != nil && e.Title != "" {
+				titleStr = fmt.Sprintf("%s (%s)", id, e.Title)
+			}
+			sort.Strings(componentFiles[id])
+			fmt.Fprintf(w, "- %s: %s\n", titleStr, strings.Join(componentFiles[id], ", "))
+		}
+		if unmapped := componentFiles[""]; len(unmapped) > 0 {
+			sort.Strings(unmapped)
+			fmt.Fprintf(w, "- (unmapped): %s\n", strings.Join(unmapped, ", "))
+		}
+	}
+
+	fmt.Fprintln(w, "\n## Decision")
+	fmt.Fprintln(w, "\n<fill in>")
+
+	// #9 — default Parent Delta to no-delta. User overrides when the change
+	// adds/removes/splits/merges a component's responsibility.
+	fmt.Fprintln(w, "\n## Parent Delta")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "no-delta: no responsibility change (override if the change adds/removes/splits/merges a component's responsibility)")
+
+	fmt.Fprintln(w, "\n## Consequences")
+	fmt.Fprintln(w, "\n<fill in>")
+
+	return nil
+}
+
+func yamlIDList(ids []string) string {
+	if len(ids) == 0 {
+		return "[]"
+	}
+	return "[" + strings.Join(ids, ", ") + "]"
+}
+
+func humanizeSlug(slug string) string {
+	parts := strings.Split(slug, "-")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, " ")
+}

--- a/cli/cmd/adr.go
+++ b/cli/cmd/adr.go
@@ -10,7 +10,6 @@ import (
 	"github.com/lagz0ne/c3-design/cli/internal/store"
 )
 
-// AdrFromDiffOptions holds parameters for `c3x adr --from-diff`.
 type AdrFromDiffOptions struct {
 	Store      *store.Store
 	C3Dir      string
@@ -19,10 +18,7 @@ type AdrFromDiffOptions struct {
 	Since      string
 }
 
-// RunAdrFromDiff prints an ADR scaffold to w, pre-populating affects: and a
-// Context section listing touched files grouped by owning component.
-// Output is markdown (frontmatter + body) — user pipes to `c3x add adr`
-// or edits and saves. Never writes to .c3/ directly.
+// RunAdrFromDiff prints an ADR scaffold to w. Never writes to .c3/.
 func RunAdrFromDiff(opts AdrFromDiffOptions, w io.Writer) error {
 	slug := opts.Slug
 	if slug == "" {
@@ -34,8 +30,6 @@ func RunAdrFromDiff(opts AdrFromDiffOptions, w io.Writer) error {
 		return fmt.Errorf("git: %w", err)
 	}
 
-	// Group touched source files by owning component. Canonical .c3/ edits
-	// contribute their entity directly.
 	componentFiles := map[string][]string{}
 	affectedParents := map[string]bool{}
 	for _, f := range files {
@@ -99,8 +93,6 @@ func RunAdrFromDiff(opts AdrFromDiffOptions, w io.Writer) error {
 	fmt.Fprintln(w, "\n## Decision")
 	fmt.Fprintln(w, "\n<fill in>")
 
-	// #9 — default Parent Delta to no-delta. User overrides when the change
-	// adds/removes/splits/merges a component's responsibility.
 	fmt.Fprintln(w, "\n## Parent Delta")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "no-delta: no responsibility change (override if the change adds/removes/splits/merges a component's responsibility)")

--- a/cli/cmd/adr.go
+++ b/cli/cmd/adr.go
@@ -78,7 +78,7 @@ func RunAdrFromDiff(opts AdrFromDiffOptions, w io.Writer) error {
 	fmt.Fprintln(w, "## Context")
 	fmt.Fprintln(w)
 	if len(files) == 0 {
-		fmt.Fprintln(w, "No touched files detected.")
+		fmt.Fprintln(w, "No touched files. Stage/edit changes, or widen scope: --since main.")
 	} else {
 		fmt.Fprintf(w, "Touches %d file(s) across %d component(s):\n\n", len(files), len(componentIDs))
 		for _, id := range componentIDs {

--- a/cli/cmd/adr_test.go
+++ b/cli/cmd/adr_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunAdrFromDiff_GroupsFilesByComponent(t *testing.T) {
+	projectDir := t.TempDir()
+	c3Dir := filepath.Join(projectDir, ".c3")
+	if err := os.MkdirAll(c3Dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	initGit(t, projectDir)
+
+	s := createRichDBFixture(t)
+	if err := s.SetCodeMap("c3-101", []string{"api/**"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetCodeMap("c3-201", []string{"web/**"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(projectDir, "api"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectDir, "web"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "README.md"), []byte("init\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, projectDir, "add", ".")
+	gitCmd(t, projectDir, "commit", "-q", "-m", "init")
+
+	// Now create uncommitted changes across two components
+	os.WriteFile(filepath.Join(projectDir, "api", "auth.go"), []byte("package api\n"), 0644)
+	os.WriteFile(filepath.Join(projectDir, "web", "renderer.ts"), []byte("export {}\n"), 0644)
+
+	var buf bytes.Buffer
+	err := RunAdrFromDiff(AdrFromDiffOptions{
+		Store: s, C3Dir: c3Dir, ProjectDir: projectDir, Slug: "refactor-auth",
+	}, &buf)
+	if err != nil {
+		t.Fatalf("RunAdrFromDiff: %v", err)
+	}
+
+	out := buf.String()
+	// Frontmatter
+	if !strings.Contains(out, "id: adr-") {
+		t.Errorf("expected id prefix, got:\n%s", out)
+	}
+	if !strings.Contains(out, "title: Refactor Auth") {
+		t.Errorf("expected humanized title, got:\n%s", out)
+	}
+	if !strings.Contains(out, "affects: [c3-1, c3-2]") {
+		t.Errorf("expected affects with both parents, got:\n%s", out)
+	}
+	// Context lists touched files per component
+	if !strings.Contains(out, "c3-101 (auth): api/auth.go") {
+		t.Errorf("expected c3-101 entry with file, got:\n%s", out)
+	}
+	if !strings.Contains(out, "c3-201 (renderer): web/renderer.ts") {
+		t.Errorf("expected c3-201 entry with file, got:\n%s", out)
+	}
+	// Parent Delta default (#9)
+	if !strings.Contains(out, "no-delta: no responsibility change") {
+		t.Errorf("expected Parent Delta no-delta default, got:\n%s", out)
+	}
+}
+
+func TestRunAdrFromDiff_UnmappedFiles(t *testing.T) {
+	projectDir := t.TempDir()
+	c3Dir := filepath.Join(projectDir, ".c3")
+	if err := os.MkdirAll(c3Dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	initGit(t, projectDir)
+
+	s := createRichDBFixture(t)
+	os.WriteFile(filepath.Join(projectDir, "README.md"), []byte("init\n"), 0644)
+	gitCmd(t, projectDir, "add", ".")
+	gitCmd(t, projectDir, "commit", "-q", "-m", "init")
+
+	os.WriteFile(filepath.Join(projectDir, "scripts.sh"), []byte("echo hi\n"), 0644)
+
+	var buf bytes.Buffer
+	if err := RunAdrFromDiff(AdrFromDiffOptions{
+		Store: s, C3Dir: c3Dir, ProjectDir: projectDir, Slug: "scripts",
+	}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "(unmapped): scripts.sh") {
+		t.Errorf("expected unmapped file entry, got:\n%s", buf.String())
+	}
+}
+
+func TestRunAdrFromDiff_NoFiles(t *testing.T) {
+	projectDir := t.TempDir()
+	c3Dir := filepath.Join(projectDir, ".c3")
+	if err := os.MkdirAll(c3Dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	initGit(t, projectDir)
+	s := createRichDBFixture(t)
+
+	var buf bytes.Buffer
+	if err := RunAdrFromDiff(AdrFromDiffOptions{
+		Store: s, C3Dir: c3Dir, ProjectDir: projectDir, Slug: "empty",
+	}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "No touched files detected.") {
+		t.Errorf("expected no-files message, got:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "affects: []") {
+		t.Errorf("expected empty affects, got:\n%s", buf.String())
+	}
+}

--- a/cli/cmd/adr_test.go
+++ b/cli/cmd/adr_test.go
@@ -113,8 +113,11 @@ func TestRunAdrFromDiff_NoFiles(t *testing.T) {
 	}, &buf); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(buf.String(), "No touched files detected.") {
+	if !strings.Contains(buf.String(), "No touched files") {
 		t.Errorf("expected no-files message, got:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "--since") {
+		t.Errorf("expected actionable hint referencing --since, got:\n%s", buf.String())
 	}
 	if !strings.Contains(buf.String(), "affects: []") {
 		t.Errorf("expected empty affects, got:\n%s", buf.String())

--- a/cli/cmd/check_enhanced.go
+++ b/cli/cmd/check_enhanced.go
@@ -77,9 +77,8 @@ func suggestByTitle(val string, titleMap map[string]string) string {
 	return ""
 }
 
-// resolveRuleCiters returns the entity IDs that cite any of the given rules
-// via a 'uses' relationship. Errors if a rule has no citers — the filter
-// would otherwise silently check nothing.
+// resolveRuleCiters errors if a rule has no citers — silently checking
+// nothing would mask the misuse.
 func resolveRuleCiters(s *store.Store, ruleIDs []string) ([]string, error) {
 	seen := map[string]bool{}
 	var ids []string
@@ -205,9 +204,6 @@ func RunCheckV2(opts CheckOptions, w io.Writer) error {
 		return entities[i].ID < entities[j].ID
 	})
 
-	// --rule expands each rule ID into the set of citer entity IDs and
-	// merges them with --only. Empty citer set is an error — the user
-	// asked for a rule that nothing cites.
 	if len(opts.Rules) > 0 {
 		ruleCiters, err := resolveRuleCiters(opts.Store, opts.Rules)
 		if err != nil {

--- a/cli/cmd/check_enhanced.go
+++ b/cli/cmd/check_enhanced.go
@@ -39,6 +39,7 @@ type CheckOptions struct {
 	IncludeADR bool
 	Fix        bool
 	Only       []string
+	Rules      []string
 }
 
 // buildTitleMapStore creates a case-insensitive title/slug -> entity ID lookup.
@@ -74,6 +75,40 @@ func suggestByTitle(val string, titleMap map[string]string) string {
 		return id
 	}
 	return ""
+}
+
+// resolveRuleCiters returns the entity IDs that cite any of the given rules
+// via a 'uses' relationship. Errors if a rule has no citers — the filter
+// would otherwise silently check nothing.
+func resolveRuleCiters(s *store.Store, ruleIDs []string) ([]string, error) {
+	seen := map[string]bool{}
+	var ids []string
+	for _, ruleID := range ruleIDs {
+		if _, err := s.GetEntity(ruleID); err != nil {
+			return nil, fmt.Errorf("--rule %s: %w", ruleID, err)
+		}
+		rels, err := s.RelationshipsTo(ruleID)
+		if err != nil {
+			return nil, fmt.Errorf("--rule %s citers: %w", ruleID, err)
+		}
+		found := false
+		for _, r := range rels {
+			if r.RelType != "uses" {
+				continue
+			}
+			found = true
+			if seen[r.FromID] {
+				continue
+			}
+			seen[r.FromID] = true
+			ids = append(ids, r.FromID)
+		}
+		if !found {
+			return nil, fmt.Errorf("--rule %s has no citers; nothing to check", ruleID)
+		}
+	}
+	sort.Strings(ids)
+	return ids, nil
 }
 
 func hintFor(message string) string {
@@ -169,6 +204,18 @@ func RunCheckV2(opts CheckOptions, w io.Writer) error {
 	sort.Slice(entities, func(i, j int) bool {
 		return entities[i].ID < entities[j].ID
 	})
+
+	// --rule expands each rule ID into the set of citer entity IDs and
+	// merges them with --only. Empty citer set is an error — the user
+	// asked for a rule that nothing cites.
+	if len(opts.Rules) > 0 {
+		ruleCiters, err := resolveRuleCiters(opts.Store, opts.Rules)
+		if err != nil {
+			return err
+		}
+		opts.Only = append(opts.Only, ruleCiters...)
+	}
+
 	targetMatcher := newCheckTargetMatcher(entities, opts.Only)
 
 	for _, entity := range entities {

--- a/cli/cmd/check_enhanced.go
+++ b/cli/cmd/check_enhanced.go
@@ -104,7 +104,7 @@ func resolveRuleCiters(s *store.Store, ruleIDs []string) ([]string, error) {
 			ids = append(ids, r.FromID)
 		}
 		if !found {
-			return nil, fmt.Errorf("--rule %s has no citers; nothing to check", ruleID)
+			return nil, fmt.Errorf("rule %s has no citers. Wire one with: c3x wire <component> %s\nOr check a different rule.", ruleID, ruleID)
 		}
 	}
 	sort.Strings(ids)

--- a/cli/cmd/check_enhanced_test.go
+++ b/cli/cmd/check_enhanced_test.go
@@ -503,3 +503,52 @@ func TestSuggestByTitle(t *testing.T) {
 		t.Errorf("suggestByTitle(nonexistent) = %q, want empty", id)
 	}
 }
+
+
+// TestRunCheck_RuleFilter verifies --rule expands to citer entities.
+func TestRunCheck_RuleFilter(t *testing.T) {
+	s := createRichDBFixture(t)
+	// Add a rule cited by c3-101.
+	if err := s.InsertEntity(&store.Entity{
+		ID: "rule-logging", Type: "rule", Title: "Structured Logging",
+		Slug: "logging", Status: "active", Metadata: "{}",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	content.WriteEntity(s, "rule-logging", "# Structured Logging\n\n## Goal\n\nConsistent logs.\n\n## Choice\n\nJSON.\n\n## Why\n\nMachine-parseable.\n")
+	if err := s.AddRelationship(&store.Relationship{FromID: "c3-101", ToID: "rule-logging", RelType: "uses"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err := RunCheckV2(CheckOptions{Store: s, JSON: true, Rules: []string{"rule-logging"}}, &buf)
+	// Errors are possible but every issue in the output must target c3-101.
+	_ = err
+	var result CheckResult
+	if jerr := json.Unmarshal(buf.Bytes(), &result); jerr != nil {
+		t.Fatalf("invalid JSON: %v\n%s", jerr, buf.String())
+	}
+	for _, issue := range result.Issues {
+		if issue.Entity != "" && issue.Entity != "c3-101" {
+			t.Errorf("--rule filter leaked to non-citer %s: %+v", issue.Entity, issue)
+		}
+	}
+}
+
+// TestRunCheck_RuleFilterNoCiters errors loudly when the rule has no citers.
+func TestRunCheck_RuleFilterNoCiters(t *testing.T) {
+	s := createRichDBFixture(t)
+	s.InsertEntity(&store.Entity{
+		ID: "rule-unused", Type: "rule", Title: "Unused",
+		Slug: "unused", Status: "active", Metadata: "{}",
+	})
+	var buf bytes.Buffer
+	err := RunCheckV2(CheckOptions{Store: s, JSON: true, Rules: []string{"rule-unused"}}, &buf)
+	if err == nil {
+		t.Fatal("expected error for rule with no citers")
+	}
+	if !strings.Contains(err.Error(), "no citers") {
+		t.Errorf("expected 'no citers' in error, got: %v", err)
+	}
+}
+

--- a/cli/cmd/check_enhanced_test.go
+++ b/cli/cmd/check_enhanced_test.go
@@ -550,5 +550,8 @@ func TestRunCheck_RuleFilterNoCiters(t *testing.T) {
 	if !strings.Contains(err.Error(), "no citers") {
 		t.Errorf("expected 'no citers' in error, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), "c3x wire") {
+		t.Errorf("expected actionable hint referencing 'c3x wire', got: %v", err)
+	}
 }
 

--- a/cli/cmd/help.go
+++ b/cli/cmd/help.go
@@ -41,7 +41,7 @@ Normal users rarely need this after initial setup.`,
 	{
 		Name:     "verify",
 		OneLiner: "Validate canonical .c3/ truth and refresh local cache if needed",
-		Help: `Usage: c3x verify [--include-adr] [--only <id-or-path-or-glob>]
+		Help: `Usage: c3x verify [--include-adr] [--only <id-or-path-or-glob>] [--only-touched [--since <ref>]]
 
 Verify that canonical .c3/ markdown is sealed, structurally valid, and in sync
 with the local cache. If c3.db is missing or stale, verify rebuilds it from the
@@ -52,6 +52,11 @@ work. Use --include-adr when finishing ADR work or before release/commit.
 
 Use --only to verify a focused set of canonical docs by entity ID or path. Repeat
 --only for multiple docs.
+
+Use --only-touched to scope verify to entities affected by uncommitted changes
+(staged + unstaged + untracked). Source file edits resolve to owning components
+via the code-map; direct canonical edits resolve via frontmatter id. Combine
+with --since <ref> to widen the window (e.g. --since main).
 
 Use this in CI and pre-commit.
 
@@ -130,7 +135,7 @@ Topology view with system goal, entity goals, file coverage, and ref usage.
 	{
 		Name:     "check",
 		OneLiner: "Validate docs, schema, code refs, consistency",
-		Help: `Usage: c3x check [--json] [--include-adr] [--fix]
+		Help: `Usage: c3x check [--json] [--include-adr] [--fix] [--only <id>] [--rule <rule-id>]
 
 Three-layer validation (ADRs excluded by default; use --include-adr to validate them):
   Layer 1: Broken links, orphans, duplicates, missing parents
@@ -138,8 +143,11 @@ Three-layer validation (ADRs excluded by default; use --include-adr to validate 
   Layer 3: Code refs exist on disk, entity IDs in graph, cite consistency
 
 Options:
-  --fix            Auto-fix entity/ref references that match by title (e.g., "API" → c3-1)
-  --include-adr    Include ADR entities in validation`,
+  --fix              Auto-fix entity/ref references that match by title (e.g., "API" → c3-1)
+  --include-adr      Include ADR entities in validation
+  --only <id>        Scope check to specific entity IDs (repeatable)
+  --rule <rule-id>   Scope check to the set of entities that cite a rule (repeatable).
+                     Errors if the rule has no citers. Composes with --only as union.`,
 	},
 	{
 		Name:     "add",
@@ -380,6 +388,27 @@ Options:
 Examples:
   c3x diff                    # show pending changes
   c3x diff --mark abc123      # mark changes as committed`,
+	},
+	{
+		Name:     "adr",
+		Args:     "[<slug>]",
+		OneLiner: "Scaffold ADRs (currently: --from-diff)",
+		Help: `Usage: c3x adr --from-diff [<slug>] [--since <ref>]
+
+Generate a pre-filled ADR scaffold from uncommitted changes. Maps touched
+files to owning components via the code-map, groups them in Context, and
+seeds affects: with the union of those components' parents. Parent Delta
+defaults to "no-delta" — override if the change adds/removes/splits/merges
+a component's responsibility.
+
+Output is markdown on stdout. Pipe to c3x add adr or save and edit:
+
+  c3x adr --from-diff refactor-auth | c3x add adr refactor-auth
+  c3x adr --from-diff refactor-auth --since main > /tmp/adr.md
+
+Options:
+  --from-diff      Required. Source scaffold from git diff.
+  --since <ref>    Diff window (default: uncommitted = HEAD + staged + untracked).`,
 	},
 	{
 		Name:     "impact",

--- a/cli/cmd/help.go
+++ b/cli/cmd/help.go
@@ -40,27 +40,23 @@ Normal users rarely need this after initial setup.`,
 	},
 	{
 		Name:     "verify",
-		OneLiner: "Validate canonical .c3/ truth and refresh local cache if needed",
-		Help: `Usage: c3x verify [--include-adr] [--only <id-or-path-or-glob>] [--only-touched [--since <ref>]]
+		OneLiner: "Validate canonical .c3/ truth; rebuild cache if needed",
+		Help: `Usage: c3x verify [--include-adr] [--only <id>] [--only-touched [--since <ref>]]
 
-Verify that canonical .c3/ markdown is sealed, structurally valid, and in sync
-with the local cache. If c3.db is missing or stale, verify rebuilds it from the
-canonical text automatically.
+Verifies canonical markdown is sealed, structurally valid, and in sync with
+the local cache. Rebuilds c3.db from canonical if missing/stale.
 
-ADRs are excluded by default so in-progress work orders do not block same-branch
-work. Use --include-adr when finishing ADR work or before release/commit.
+ADRs skipped by default (in-progress work orders shouldn't block same-branch
+reads). Add --include-adr before release/commit.
 
-Use --only to verify a focused set of canonical docs by entity ID or path. Repeat
---only for multiple docs.
+  --only <id>        Scope to specific entities/paths (repeatable)
+  --only-touched     Scope to entities affected by uncommitted changes.
+                     Source edits → components via codemap; canonical edits
+                     → entity id via frontmatter.
+  --since <ref>      Widen --only-touched window (e.g. --since main)
+  --include-adr      Include ADR entities
 
-Use --only-touched to scope verify to entities affected by uncommitted changes
-(staged + unstaged + untracked). Source file edits resolve to owning components
-via the code-map; direct canonical edits resolve via frontmatter id. Combine
-with --since <ref> to widen the window (e.g. --since main).
-
-Use this in CI and pre-commit.
-
-User rule: if you want confidence before commit, run c3x verify --include-adr.`,
+Use in CI + pre-commit. Before commit: c3x verify --include-adr.`,
 	},
 	{
 		Name:     "repair",
@@ -392,47 +388,39 @@ Examples:
 	{
 		Name:     "adr",
 		Args:     "[<slug>]",
-		OneLiner: "Scaffold ADRs (currently: --from-diff)",
+		OneLiner: "Scaffold an ADR from a git diff",
 		Help: `Usage: c3x adr --from-diff [<slug>] [--since <ref>]
 
-Generate a pre-filled ADR scaffold from uncommitted changes. Maps touched
-files to owning components via the code-map, groups them in Context, and
-seeds affects: with the union of those components' parents. Parent Delta
-defaults to "no-delta" — override if the change adds/removes/splits/merges
-a component's responsibility.
+Emits an ADR scaffold to stdout. Touched files → components via codemap.
+affects: seeded from those components' parents. Parent Delta defaults to
+no-delta; override if responsibility changed.
 
-Output is markdown on stdout. Pipe to c3x add adr or save and edit:
+  --from-diff      Required. Source from git diff.
+  --since <ref>    Diff window (default: uncommitted = HEAD + staged + untracked).
 
+Examples:
   c3x adr --from-diff refactor-auth | c3x add adr refactor-auth
-  c3x adr --from-diff refactor-auth --since main > /tmp/adr.md
-
-Options:
-  --from-diff      Required. Source scaffold from git diff.
-  --since <ref>    Diff window (default: uncommitted = HEAD + staged + untracked).`,
+  c3x adr --from-diff refactor-auth --since main > /tmp/adr.md`,
 	},
 	{
 		Name:     "impact",
 		Args:     "<entity-id>",
-		OneLiner: "Transitive impact analysis (who depends on this?)",
+		OneLiner: "Who depends on this? (docs + optional grep)",
 		Help: `Usage: c3x impact <entity-id> [--depth N] [--include-code] [--json]
 
-Find all entities affected by changes to the given entity.
-Traverses reverse 'uses' + forward 'affects' relationships.
+Traverses 'uses' (reverse) + 'affects' (forward) relationships.
 
-With --include-code, merges the documented citation graph with a grep-derived
-import graph over the target's code-map sources. Components that call into
-the target but are not documented in .c3/ are flagged [uncited]. Caller files
-with no owning component are listed separately as codemap coverage gaps.
+--include-code: merge grep-derived callers. Undocumented ones flagged [uncited].
+Caller files with no component owner surface as codemap gaps.
 
-Options:
-  --depth N         Max traversal depth (default: 3)
-  --include-code    Merge documented citations with grep-derived callers (off by default)
-  --json            Machine-readable output
+  --depth N         Max depth (default 3)
+  --include-code    Add grep-derived callers
+  --json            Machine-readable
 
 Examples:
-  c3x impact c3-101                  # what breaks if auth changes?
-  c3x impact ref-jwt --depth 5       # deep impact of JWT ref
-  c3x impact c3-201 --include-code   # include undocumented callers as [uncited]`,
+  c3x impact c3-101
+  c3x impact ref-jwt --depth 5
+  c3x impact c3-201 --include-code`,
 	},
 	{
 		Name:     "export",

--- a/cli/cmd/help.go
+++ b/cli/cmd/help.go
@@ -385,18 +385,25 @@ Examples:
 		Name:     "impact",
 		Args:     "<entity-id>",
 		OneLiner: "Transitive impact analysis (who depends on this?)",
-		Help: `Usage: c3x impact <entity-id> [--depth N] [--json]
+		Help: `Usage: c3x impact <entity-id> [--depth N] [--include-code] [--json]
 
 Find all entities affected by changes to the given entity.
 Traverses reverse 'uses' + forward 'affects' relationships.
 
+With --include-code, merges the documented citation graph with a grep-derived
+import graph over the target's code-map sources. Components that call into
+the target but are not documented in .c3/ are flagged [uncited]. Caller files
+with no owning component are listed separately as codemap coverage gaps.
+
 Options:
-  --depth N   Max traversal depth (default: 3)
-  --json      Machine-readable output
+  --depth N         Max traversal depth (default: 3)
+  --include-code    Merge documented citations with grep-derived callers (off by default)
+  --json            Machine-readable output
 
 Examples:
-  c3x impact c3-101            # what breaks if auth changes?
-  c3x impact ref-jwt --depth 5 # deep impact of JWT ref`,
+  c3x impact c3-101                  # what breaks if auth changes?
+  c3x impact ref-jwt --depth 5       # deep impact of JWT ref
+  c3x impact c3-201 --include-code   # include undocumented callers as [uncited]`,
 	},
 	{
 		Name:     "export",

--- a/cli/cmd/help_test.go
+++ b/cli/cmd/help_test.go
@@ -48,7 +48,7 @@ func TestShowHelp_VerifyMentionsCacheRefresh(t *testing.T) {
 	if !strings.Contains(strings.ToLower(output), "local cache") {
 		t.Fatal("verify help should mention cache refresh")
 	}
-	requireAll(t, output, "--only <id-or-path-or-glob>", "--include-adr")
+	requireAll(t, output, "--only <id>", "--include-adr")
 }
 
 func TestShowHelp_AddADRWorkflowPointsAtSchema(t *testing.T) {

--- a/cli/cmd/impact.go
+++ b/cli/cmd/impact.go
@@ -3,16 +3,38 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"sort"
 
+	"github.com/lagz0ne/c3-design/cli/internal/codemap"
 	"github.com/lagz0ne/c3-design/cli/internal/store"
 )
 
 // ImpactOptions holds parameters for the impact command.
 type ImpactOptions struct {
-	Store    *store.Store
-	EntityID string
-	Depth    int
-	JSON     bool
+	Store       *store.Store
+	EntityID    string
+	Depth       int
+	JSON        bool
+	IncludeCode bool
+	ProjectDir  string
+}
+
+// ImpactEntry is a single row in the impact output. Uncited=true means the
+// entry came from the grep-derived import graph but is not documented in .c3/.
+type ImpactEntry struct {
+	ID      string `json:"id"`
+	Title   string `json:"title"`
+	Type    string `json:"type"`
+	Depth   int    `json:"depth"`
+	Uncited bool   `json:"uncited,omitempty"`
+}
+
+// ImpactOutput wraps entries plus unmapped grep-derived files (files that
+// reference the target but have no component mapping — these surface
+// codemap coverage gaps alongside the impact list).
+type ImpactOutput struct {
+	Entries       []ImpactEntry `json:"entries"`
+	UnmappedFiles []string      `json:"unmapped_files,omitempty"`
 }
 
 // RunImpact performs transitive impact analysis on an entity.
@@ -26,30 +48,147 @@ func RunImpact(opts ImpactOptions, w io.Writer) error {
 		depth = 3
 	}
 
-	results, err := opts.Store.Impact(opts.EntityID, depth)
+	docResults, err := opts.Store.Impact(opts.EntityID, depth)
 	if err != nil {
 		return fmt.Errorf("impact analysis: %w", err)
 	}
 
-	if len(results) == 0 {
+	byID := map[string]*ImpactEntry{}
+	var entries []*ImpactEntry
+	for _, r := range docResults {
+		e := &ImpactEntry{ID: r.ID, Title: r.Title, Type: r.Type, Depth: r.Depth}
+		byID[r.ID] = e
+		entries = append(entries, e)
+	}
+
+	var unmapped []string
+	if opts.IncludeCode {
+		unmappedFiles, codeErr := mergeCodeCallers(opts, byID, &entries)
+		if codeErr != nil {
+			return fmt.Errorf("impact --include-code: %w", codeErr)
+		}
+		unmapped = unmappedFiles
+	}
+
+	if len(entries) == 0 && len(unmapped) == 0 {
+		if opts.JSON {
+			return writeJSON(w, ImpactOutput{Entries: []ImpactEntry{}})
+		}
 		fmt.Fprintln(w, "No affected entities found.")
 		return nil
 	}
 
+	sortEntries(entries)
+
 	if opts.JSON {
-		return writeJSON(w, results)
+		out := ImpactOutput{Entries: make([]ImpactEntry, 0, len(entries)), UnmappedFiles: unmapped}
+		for _, e := range entries {
+			out.Entries = append(out.Entries, *e)
+		}
+		return writeJSON(w, out)
 	}
 
-	// Get entity title for header
 	title := opts.EntityID
 	if e, err := opts.Store.GetEntity(opts.EntityID); err == nil {
 		title = e.Title
 	}
 
 	fmt.Fprintf(w, "Impact of %s (%s):\n", opts.EntityID, title)
-	for _, r := range results {
-		fmt.Fprintf(w, "  depth %d: %s [%s] %s\n", r.Depth, r.ID, r.Type, r.Title)
+	for _, e := range entries {
+		suffix := ""
+		if e.Uncited {
+			suffix = " [uncited]"
+		}
+		fmt.Fprintf(w, "  depth %d: %s [%s] %s%s\n", e.Depth, e.ID, e.Type, e.Title, suffix)
+	}
+	if len(unmapped) > 0 {
+		fmt.Fprintln(w, "\nUnmapped callers (no owning component):")
+		for _, f := range unmapped {
+			fmt.Fprintf(w, "  %s\n", f)
+		}
 	}
 
 	return nil
+}
+
+// mergeCodeCallers derives callers via grep over the target's code-map
+// sources, maps them to component IDs, and merges into entries. Components
+// that are not in the documented results are flagged Uncited=true at depth 1.
+func mergeCodeCallers(opts ImpactOptions, byID map[string]*ImpactEntry, entries *[]*ImpactEntry) ([]string, error) {
+	if opts.ProjectDir == "" {
+		return nil, fmt.Errorf("project directory unavailable")
+	}
+
+	patterns, err := opts.Store.CodeMapFor(opts.EntityID)
+	if err != nil {
+		return nil, fmt.Errorf("codemap lookup: %w", err)
+	}
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+
+	allFiles, err := codemap.ListProjectFiles(opts.ProjectDir)
+	if err != nil {
+		return nil, fmt.Errorf("list project files: %w", err)
+	}
+	cm := codemap.CodeMap{opts.EntityID: patterns}
+	var targetSources []string
+	for _, f := range allFiles {
+		if ids := codemap.Match(cm, f); len(ids) > 0 {
+			targetSources = append(targetSources, f)
+		}
+	}
+	if len(targetSources) == 0 {
+		return nil, nil
+	}
+
+	callers, err := codemap.DeriveCallers(opts.ProjectDir, targetSources)
+	if err != nil {
+		return nil, err
+	}
+
+	var unmapped []string
+	seenUnmapped := map[string]bool{}
+	for _, caller := range callers {
+		ids, _ := opts.Store.LookupByFile(caller)
+		if len(ids) == 0 {
+			if !seenUnmapped[caller] {
+				seenUnmapped[caller] = true
+				unmapped = append(unmapped, caller)
+			}
+			continue
+		}
+		for _, id := range ids {
+			if id == opts.EntityID {
+				continue
+			}
+			if _, ok := byID[id]; ok {
+				continue
+			}
+			entity, eerr := opts.Store.GetEntity(id)
+			if eerr != nil {
+				continue
+			}
+			entry := &ImpactEntry{
+				ID:      id,
+				Title:   entity.Title,
+				Type:    entity.Type,
+				Depth:   1,
+				Uncited: true,
+			}
+			byID[id] = entry
+			*entries = append(*entries, entry)
+		}
+	}
+	sort.Strings(unmapped)
+	return unmapped, nil
+}
+
+func sortEntries(entries []*ImpactEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].Depth != entries[j].Depth {
+			return entries[i].Depth < entries[j].Depth
+		}
+		return entries[i].ID < entries[j].ID
+	})
 }

--- a/cli/cmd/impact.go
+++ b/cli/cmd/impact.go
@@ -19,8 +19,9 @@ type ImpactOptions struct {
 	ProjectDir  string
 }
 
-// ImpactEntry is a single row in the impact output. Uncited=true means the
-// entry came from the grep-derived import graph but is not documented in .c3/.
+// ImpactEntry is one row of impact output. Uncited=true marks entries
+// discovered only by grep, not by docs — the user should treat them as
+// "needs review" rather than ground truth.
 type ImpactEntry struct {
 	ID      string `json:"id"`
 	Title   string `json:"title"`
@@ -29,9 +30,6 @@ type ImpactEntry struct {
 	Uncited bool   `json:"uncited,omitempty"`
 }
 
-// ImpactOutput wraps entries plus unmapped grep-derived files (files that
-// reference the target but have no component mapping — these surface
-// codemap coverage gaps alongside the impact list).
 type ImpactOutput struct {
 	Entries       []ImpactEntry `json:"entries"`
 	UnmappedFiles []string      `json:"unmapped_files,omitempty"`
@@ -118,9 +116,6 @@ func RunImpact(opts ImpactOptions, w io.Writer) error {
 	return nil
 }
 
-// mergeCodeCallers derives callers via grep over the target's code-map
-// sources, maps them to component IDs, and merges into entries. Components
-// that are not in the documented results are flagged Uncited=true at depth 1.
 func mergeCodeCallers(opts ImpactOptions, byID map[string]*ImpactEntry, entries *[]*ImpactEntry) ([]string, error) {
 	if opts.ProjectDir == "" {
 		return nil, fmt.Errorf("project dir unresolved; run from inside the project or pass --c3-dir")

--- a/cli/cmd/impact.go
+++ b/cli/cmd/impact.go
@@ -40,7 +40,7 @@ type ImpactOutput struct {
 // RunImpact performs transitive impact analysis on an entity.
 func RunImpact(opts ImpactOptions, w io.Writer) error {
 	if opts.EntityID == "" {
-		return fmt.Errorf("error: impact requires an <entity-id> argument\nhint: run 'c3x impact <entity-id>' to analyze")
+		return fmt.Errorf("usage: c3x impact <entity-id>\n       c3x impact c3-101\n       c3x impact ref-jwt --include-code")
 	}
 
 	depth := opts.Depth
@@ -74,7 +74,13 @@ func RunImpact(opts ImpactOptions, w io.Writer) error {
 		if opts.JSON {
 			return writeJSON(w, ImpactOutput{Entries: []ImpactEntry{}})
 		}
-		fmt.Fprintln(w, "No affected entities found.")
+		if opts.IncludeCode {
+			fmt.Fprintf(w, "No affected entities for %s (docs + grep).\n", opts.EntityID)
+			fmt.Fprintln(w, "hint: verify codemap covers this entity: c3x codemap")
+		} else {
+			fmt.Fprintf(w, "No cited callers for %s.\n", opts.EntityID)
+			fmt.Fprintln(w, "hint: re-run with --include-code to surface undocumented callers via grep")
+		}
 		return nil
 	}
 
@@ -102,10 +108,11 @@ func RunImpact(opts ImpactOptions, w io.Writer) error {
 		fmt.Fprintf(w, "  depth %d: %s [%s] %s%s\n", e.Depth, e.ID, e.Type, e.Title, suffix)
 	}
 	if len(unmapped) > 0 {
-		fmt.Fprintln(w, "\nUnmapped callers (no owning component):")
+		fmt.Fprintln(w, "\nCaller files with no component owner (codemap gap):")
 		for _, f := range unmapped {
 			fmt.Fprintf(w, "  %s\n", f)
 		}
+		fmt.Fprintln(w, "hint: wire these into a component's codemap via c3x codemap")
 	}
 
 	return nil
@@ -116,7 +123,7 @@ func RunImpact(opts ImpactOptions, w io.Writer) error {
 // that are not in the documented results are flagged Uncited=true at depth 1.
 func mergeCodeCallers(opts ImpactOptions, byID map[string]*ImpactEntry, entries *[]*ImpactEntry) ([]string, error) {
 	if opts.ProjectDir == "" {
-		return nil, fmt.Errorf("project directory unavailable")
+		return nil, fmt.Errorf("project dir unresolved; run from inside the project or pass --c3-dir")
 	}
 
 	patterns, err := opts.Store.CodeMapFor(opts.EntityID)

--- a/cli/cmd/impact_test.go
+++ b/cli/cmd/impact_test.go
@@ -36,8 +36,11 @@ func TestRunImpact_NoAffected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunImpact: %v", err)
 	}
-	if !strings.Contains(buf.String(), "No affected entities found.") {
-		t.Errorf("expected 'No affected entities found.', got:\n%s", buf.String())
+	if !strings.Contains(buf.String(), "No cited callers") {
+		t.Errorf("expected no-callers message, got:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "--include-code") {
+		t.Errorf("expected actionable hint referencing --include-code, got:\n%s", buf.String())
 	}
 }
 

--- a/cli/cmd/impact_test.go
+++ b/cli/cmd/impact_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -46,12 +48,17 @@ func TestRunImpact_JSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunImpact JSON: %v", err)
 	}
-	var results []store.ImpactResult
-	if err := json.Unmarshal(buf.Bytes(), &results); err != nil {
+	var out ImpactOutput
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
 		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
 	}
-	if len(results) == 0 {
-		t.Error("expected at least one impact result")
+	if len(out.Entries) == 0 {
+		t.Error("expected at least one impact entry")
+	}
+	for _, e := range out.Entries {
+		if e.Uncited {
+			t.Errorf("expected documented entry, got uncited: %+v", e)
+		}
 	}
 }
 
@@ -61,5 +68,153 @@ func TestRunImpact_EmptyEntityID(t *testing.T) {
 	err := RunImpact(ImpactOptions{Store: s, EntityID: ""}, &buf)
 	if err == nil {
 		t.Fatal("expected error for empty entity ID")
+	}
+}
+
+// TestRunImpact_IncludeCode verifies --include-code surfaces grep-derived
+// callers as [uncited] entries when the target's codemap sources appear in
+// other files.
+func TestRunImpact_IncludeCode(t *testing.T) {
+	s := createRichDBFixture(t)
+
+	// Register code-map globs so LookupByFile can resolve files -> components.
+	if err := s.SetCodeMap("c3-201", []string{"web/renderer/**"}); err != nil {
+		t.Fatalf("SetCodeMap c3-201: %v", err)
+	}
+	if err := s.SetCodeMap("c3-101", []string{"api/auth/**"}); err != nil {
+		t.Fatalf("SetCodeMap c3-101: %v", err)
+	}
+
+	projectDir := t.TempDir()
+	writeProjectFile(t, projectDir, "web/renderer/html.ts", "export function render() {}\n")
+	writeProjectFile(t, projectDir, "api/auth/login.ts",
+		"import { render } from '../../web/renderer/html';\nrender();\n")
+
+	var buf bytes.Buffer
+	err := RunImpact(ImpactOptions{
+		Store:       s,
+		EntityID:    "c3-201",
+		Depth:       3,
+		IncludeCode: true,
+		ProjectDir:  projectDir,
+	}, &buf)
+	if err != nil {
+		t.Fatalf("RunImpact --include-code: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "c3-101") {
+		t.Errorf("expected c3-101 as grep-derived caller of c3-201, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[uncited]") {
+		t.Errorf("expected [uncited] marker on grep-derived caller, got:\n%s", out)
+	}
+}
+
+func TestRunImpact_IncludeCode_JSON(t *testing.T) {
+	s := createRichDBFixture(t)
+	if err := s.SetCodeMap("c3-201", []string{"web/renderer/**"}); err != nil {
+		t.Fatalf("SetCodeMap c3-201: %v", err)
+	}
+	if err := s.SetCodeMap("c3-101", []string{"api/auth/**"}); err != nil {
+		t.Fatalf("SetCodeMap c3-101: %v", err)
+	}
+
+	projectDir := t.TempDir()
+	writeProjectFile(t, projectDir, "web/renderer/html.ts", "export function render() {}\n")
+	writeProjectFile(t, projectDir, "api/auth/login.ts",
+		"import { render } from '../../web/renderer/html';\n")
+	// A caller file with no owning component — should appear in UnmappedFiles.
+	writeProjectFile(t, projectDir, "scripts/seed.ts",
+		"import { render } from '../web/renderer/html';\n")
+
+	var buf bytes.Buffer
+	err := RunImpact(ImpactOptions{
+		Store:       s,
+		EntityID:    "c3-201",
+		Depth:       3,
+		JSON:        true,
+		IncludeCode: true,
+		ProjectDir:  projectDir,
+	}, &buf)
+	if err != nil {
+		t.Fatalf("RunImpact --include-code --json: %v", err)
+	}
+	var out ImpactOutput
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+
+	var found *ImpactEntry
+	for i := range out.Entries {
+		if out.Entries[i].ID == "c3-101" {
+			found = &out.Entries[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected c3-101 as uncited caller, entries: %+v", out.Entries)
+	}
+	if !found.Uncited {
+		t.Errorf("expected uncited=true on grep-derived caller, got: %+v", found)
+	}
+	if len(out.UnmappedFiles) == 0 {
+		t.Errorf("expected unmapped callers to surface, got empty list")
+	}
+	if !containsStr2(out.UnmappedFiles, "scripts/seed.ts") {
+		t.Errorf("expected scripts/seed.ts in unmapped_files, got: %v", out.UnmappedFiles)
+	}
+}
+
+// TestRunImpact_IncludeCode_MergesCited verifies documented callers are NOT
+// flagged uncited even when the grep-derived graph also finds them.
+func TestRunImpact_IncludeCode_MergesCited(t *testing.T) {
+	s := createRichDBFixture(t)
+	// Wire c3-101 to cite c3-201 via 'uses' so it's a documented caller.
+	if err := s.AddRelationship(&store.Relationship{FromID: "c3-101", ToID: "c3-201", RelType: "uses"}); err != nil {
+		t.Fatalf("seed uses rel: %v", err)
+	}
+	if err := s.SetCodeMap("c3-201", []string{"web/renderer/**"}); err != nil {
+		t.Fatalf("SetCodeMap c3-201: %v", err)
+	}
+	if err := s.SetCodeMap("c3-101", []string{"api/auth/**"}); err != nil {
+		t.Fatalf("SetCodeMap c3-101: %v", err)
+	}
+
+	projectDir := t.TempDir()
+	writeProjectFile(t, projectDir, "web/renderer/html.ts", "export function render() {}\n")
+	writeProjectFile(t, projectDir, "api/auth/login.ts",
+		"import { render } from '../../web/renderer/html';\n")
+
+	var buf bytes.Buffer
+	err := RunImpact(ImpactOptions{
+		Store:       s,
+		EntityID:    "c3-201",
+		Depth:       3,
+		JSON:        true,
+		IncludeCode: true,
+		ProjectDir:  projectDir,
+	}, &buf)
+	if err != nil {
+		t.Fatalf("RunImpact: %v", err)
+	}
+	var out ImpactOutput
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	for _, e := range out.Entries {
+		if e.ID == "c3-101" && e.Uncited {
+			t.Errorf("c3-101 is documented; should NOT be flagged uncited: %+v", e)
+		}
+	}
+}
+
+func writeProjectFile(t *testing.T, projectDir, relPath, content string) {
+	t.Helper()
+	abs := filepath.Join(projectDir, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(abs), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", abs, err)
 	}
 }

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -41,6 +41,7 @@ type Options struct {
 	JSONExplicit  bool
 	Force         bool
 	Only          []string
+	IncludeCode   bool
 }
 
 // ParseArgs parses command-line arguments into Options.
@@ -90,6 +91,8 @@ func ParseArgs(argv []string) Options {
 			opts.Append = true
 		case "--include-adr":
 			opts.IncludeADR = true
+		case "--include-code":
+			opts.IncludeCode = true
 		case "--fix":
 			opts.Fix = true
 		case "--remove":

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -42,6 +42,10 @@ type Options struct {
 	Force         bool
 	Only          []string
 	IncludeCode   bool
+	Rules         []string
+	OnlyTouched   bool
+	Since         string
+	FromDiff      bool
 }
 
 // ParseArgs parses command-line arguments into Options.
@@ -153,6 +157,20 @@ func ParseArgs(argv []string) Options {
 				i++
 				opts.Only = append(opts.Only, argv[i])
 			}
+		case "--rule":
+			if i+1 < len(argv) {
+				i++
+				opts.Rules = append(opts.Rules, argv[i])
+			}
+		case "--only-touched":
+			opts.OnlyTouched = true
+		case "--since":
+			if i+1 < len(argv) {
+				i++
+				opts.Since = argv[i]
+			}
+		case "--from-diff":
+			opts.FromDiff = true
 		case "--keep":
 			if i+1 < len(argv) {
 				i++

--- a/cli/cmd/touched.go
+++ b/cli/cmd/touched.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/lagz0ne/c3-design/cli/internal/frontmatter"
+	"github.com/lagz0ne/c3-design/cli/internal/store"
+)
+
+// ResolveTouchedTargets returns entity IDs affected by files changed since
+// `since` (empty = uncommitted: staged + unstaged + untracked). Direct
+// canonical edits are parsed for their frontmatter id; source file edits
+// map to components via the store's code-map.
+func ResolveTouchedTargets(projectDir, c3Dir, since string) ([]string, error) {
+	s, err := store.Open(filepath.Join(c3Dir, "c3.db"))
+	if err != nil {
+		return nil, fmt.Errorf("open store: %w", err)
+	}
+	defer s.Close()
+	return resolveTouchedTargetsWithStore(projectDir, c3Dir, since, s)
+}
+
+// resolveTouchedTargetsWithStore is the test-friendly variant that accepts
+// an already-open store.
+func resolveTouchedTargetsWithStore(projectDir, c3Dir, since string, s *store.Store) ([]string, error) {
+	files, err := gitTouchedFiles(projectDir, since)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[string]bool{}
+	var targets []string
+	addID := func(id string) {
+		if id == "" || seen[id] {
+			return
+		}
+		seen[id] = true
+		targets = append(targets, id)
+	}
+
+	c3Rel, _ := filepath.Rel(projectDir, c3Dir)
+	c3Rel = filepath.ToSlash(c3Rel)
+	if c3Rel == "" {
+		c3Rel = ".c3"
+	}
+
+	for _, f := range files {
+		f = filepath.ToSlash(f)
+		// Direct canonical .md edit → parse frontmatter for id
+		if strings.HasPrefix(f, c3Rel+"/") && strings.HasSuffix(f, ".md") {
+			abs := filepath.Join(projectDir, f)
+			if data, rerr := os.ReadFile(abs); rerr == nil {
+				if fm, _ := frontmatter.ParseFrontmatter(string(data)); fm != nil && fm.ID != "" {
+					addID(fm.ID)
+					continue
+				}
+			}
+		}
+		// Source file edit → map to component(s) via codemap
+		ids, _ := s.LookupByFile(f)
+		for _, id := range ids {
+			addID(id)
+		}
+	}
+	sort.Strings(targets)
+	return targets, nil
+}
+
+// gitTouchedFiles returns the set of files changed since `since`. Empty
+// since means uncommitted work (staged + unstaged + untracked).
+func gitTouchedFiles(projectDir, since string) ([]string, error) {
+	cmds := [][]string{}
+	if since == "" {
+		// Uncommitted work: staged + unstaged + untracked (exclude ignored)
+		cmds = append(cmds,
+			[]string{"diff", "--name-only", "HEAD"},
+			[]string{"ls-files", "--others", "--exclude-standard"},
+		)
+	} else {
+		cmds = append(cmds,
+			[]string{"diff", "--name-only", since + "..HEAD"},
+			[]string{"diff", "--name-only"},
+		)
+	}
+
+	seen := map[string]bool{}
+	var all []string
+	for _, args := range cmds {
+		full := append([]string{"-C", projectDir}, args...)
+		out, err := exec.Command("git", full...).Output()
+		if err != nil {
+			// If HEAD doesn't exist (fresh repo) skip that cmd
+			continue
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || seen[line] {
+				continue
+			}
+			seen[line] = true
+			all = append(all, line)
+		}
+	}
+	return all, nil
+}

--- a/cli/cmd/touched.go
+++ b/cli/cmd/touched.go
@@ -13,9 +13,7 @@ import (
 )
 
 // ResolveTouchedTargets returns entity IDs affected by files changed since
-// `since` (empty = uncommitted: staged + unstaged + untracked). Direct
-// canonical edits are parsed for their frontmatter id; source file edits
-// map to components via the store's code-map.
+// `since` (empty = uncommitted: staged + unstaged + untracked).
 func ResolveTouchedTargets(projectDir, c3Dir, since string) ([]string, error) {
 	s, err := store.Open(filepath.Join(c3Dir, "c3.db"))
 	if err != nil {
@@ -25,8 +23,6 @@ func ResolveTouchedTargets(projectDir, c3Dir, since string) ([]string, error) {
 	return resolveTouchedTargetsWithStore(projectDir, c3Dir, since, s)
 }
 
-// resolveTouchedTargetsWithStore is the test-friendly variant that accepts
-// an already-open store.
 func resolveTouchedTargetsWithStore(projectDir, c3Dir, since string, s *store.Store) ([]string, error) {
 	files, err := gitTouchedFiles(projectDir, since)
 	if err != nil {
@@ -51,7 +47,6 @@ func resolveTouchedTargetsWithStore(projectDir, c3Dir, since string, s *store.St
 
 	for _, f := range files {
 		f = filepath.ToSlash(f)
-		// Direct canonical .md edit → parse frontmatter for id
 		if strings.HasPrefix(f, c3Rel+"/") && strings.HasSuffix(f, ".md") {
 			abs := filepath.Join(projectDir, f)
 			if data, rerr := os.ReadFile(abs); rerr == nil {
@@ -61,7 +56,6 @@ func resolveTouchedTargetsWithStore(projectDir, c3Dir, since string, s *store.St
 				}
 			}
 		}
-		// Source file edit → map to component(s) via codemap
 		ids, _ := s.LookupByFile(f)
 		for _, id := range ids {
 			addID(id)
@@ -71,12 +65,11 @@ func resolveTouchedTargetsWithStore(projectDir, c3Dir, since string, s *store.St
 	return targets, nil
 }
 
-// gitTouchedFiles returns the set of files changed since `since`. Empty
-// since means uncommitted work (staged + unstaged + untracked).
+// gitTouchedFiles returns files changed since `since`; empty since means
+// uncommitted (staged + unstaged + untracked).
 func gitTouchedFiles(projectDir, since string) ([]string, error) {
 	cmds := [][]string{}
 	if since == "" {
-		// Uncommitted work: staged + unstaged + untracked (exclude ignored)
 		cmds = append(cmds,
 			[]string{"diff", "--name-only", "HEAD"},
 			[]string{"ls-files", "--others", "--exclude-standard"},
@@ -94,7 +87,6 @@ func gitTouchedFiles(projectDir, since string) ([]string, error) {
 		full := append([]string{"-C", projectDir}, args...)
 		out, err := exec.Command("git", full...).Output()
 		if err != nil {
-			// If HEAD doesn't exist (fresh repo) skip that cmd
 			continue
 		}
 		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {

--- a/cli/cmd/touched_test.go
+++ b/cli/cmd/touched_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestResolveTouchedTargets_SourceEdit(t *testing.T) {
+	projectDir := t.TempDir()
+	c3Dir := filepath.Join(projectDir, ".c3")
+	if err := os.MkdirAll(c3Dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	initGit(t, projectDir)
+
+	s := createRichDBFixture(t)
+	if err := s.SetCodeMap("c3-101", []string{"api/**"}); err != nil {
+		t.Fatal(err)
+	}
+
+	srcPath := filepath.Join(projectDir, "api", "auth.go")
+	if err := os.MkdirAll(filepath.Dir(srcPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(srcPath, []byte("package api\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, projectDir, "add", ".")
+	gitCmd(t, projectDir, "commit", "-q", "-m", "init")
+	if err := os.WriteFile(srcPath, []byte("package api\n// edit\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	targets, err := resolveTouchedTargetsWithStore(projectDir, c3Dir, "", s)
+	if err != nil {
+		t.Fatalf("resolveTouchedTargets: %v", err)
+	}
+	if !containsStr2(targets, "c3-101") {
+		t.Errorf("expected c3-101 (codemap mapped from api/auth.go), got %v", targets)
+	}
+}
+
+func TestResolveTouchedTargets_CanonicalEdit(t *testing.T) {
+	projectDir := t.TempDir()
+	c3Dir := filepath.Join(projectDir, ".c3")
+	if err := os.MkdirAll(filepath.Join(c3Dir, "c3-1-api"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	initGit(t, projectDir)
+
+	s := createRichDBFixture(t)
+	authPath := filepath.Join(c3Dir, "c3-1-api", "c3-101-auth.md")
+	initial := "---\nid: c3-101\ntitle: auth\n---\n\n# auth\n"
+	if err := os.WriteFile(authPath, []byte(initial), 0644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, projectDir, "add", ".")
+	gitCmd(t, projectDir, "commit", "-q", "-m", "init")
+	if err := os.WriteFile(authPath, []byte(initial+"\n## Goal\n\nNew goal\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	targets, err := resolveTouchedTargetsWithStore(projectDir, c3Dir, "", s)
+	if err != nil {
+		t.Fatalf("resolveTouchedTargets: %v", err)
+	}
+	sort.Strings(targets)
+	if !containsStr2(targets, "c3-101") {
+		t.Errorf("expected c3-101 from canonical edit, got %v", targets)
+	}
+}
+
+func initGit(t *testing.T, dir string) {
+	t.Helper()
+	gitCmd(t, dir, "init", "-q")
+	gitCmd(t, dir, "config", "user.email", "test@test")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "commit.gpgsign", "false")
+}
+
+func gitCmd(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	full := append([]string{"-C", dir}, args...)
+	out, err := exec.Command("git", full...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}

--- a/cli/internal/codemap/importgraph.go
+++ b/cli/internal/codemap/importgraph.go
@@ -7,14 +7,11 @@ import (
 	"strings"
 )
 
-// DeriveCallers returns project-relative file paths that appear to reference
-// any of the given targetSources (grep-derived, heuristic). targetSources are
-// themselves excluded from the result. Paths are forward-slash normalized.
-//
-// Heuristic: a file is a caller if it contains the target's relative path
-// or its extensionless form as a substring. This is coarse enough to catch
-// import statements across common languages (Go, TS/JS, Python, Rust, Java)
-// without parsing each dialect.
+// DeriveCallers returns project-relative paths that appear to import or
+// reference any of targetSources. Heuristic substring match on the path
+// and its extensionless form — coarse enough to span Go/TS/JS/Py/Rust
+// without parsing each dialect, false positives surface as [uncited]
+// for review rather than as ground truth.
 func DeriveCallers(projectDir string, targetSources []string) ([]string, error) {
 	if len(targetSources) == 0 {
 		return nil, nil

--- a/cli/internal/codemap/importgraph.go
+++ b/cli/internal/codemap/importgraph.go
@@ -1,0 +1,101 @@
+package codemap
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// DeriveCallers returns project-relative file paths that appear to reference
+// any of the given targetSources (grep-derived, heuristic). targetSources are
+// themselves excluded from the result. Paths are forward-slash normalized.
+//
+// Heuristic: a file is a caller if it contains the target's relative path
+// or its extensionless form as a substring. This is coarse enough to catch
+// import statements across common languages (Go, TS/JS, Python, Rust, Java)
+// without parsing each dialect.
+func DeriveCallers(projectDir string, targetSources []string) ([]string, error) {
+	if len(targetSources) == 0 {
+		return nil, nil
+	}
+
+	targetSet := make(map[string]bool, len(targetSources))
+	var tokens []string
+	tokenSeen := map[string]bool{}
+	for _, src := range targetSources {
+		src = filepath.ToSlash(strings.TrimSpace(src))
+		if src == "" {
+			continue
+		}
+		targetSet[src] = true
+		if !tokenSeen[src] {
+			tokenSeen[src] = true
+			tokens = append(tokens, src)
+		}
+		if ext := filepath.Ext(src); ext != "" {
+			noExt := strings.TrimSuffix(src, ext)
+			if !tokenSeen[noExt] {
+				tokenSeen[noExt] = true
+				tokens = append(tokens, noExt)
+			}
+		}
+	}
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+
+	files, err := ListProjectFiles(projectDir)
+	if err != nil {
+		return nil, err
+	}
+
+	const maxFileBytes = 2 * 1024 * 1024 // 2MB cap per file to bound cost
+	var callers []string
+	seen := map[string]bool{}
+	for _, rel := range files {
+		if targetSet[rel] {
+			continue
+		}
+		if !isTextFileCandidate(rel) {
+			continue
+		}
+		abs := filepath.Join(projectDir, rel)
+		info, statErr := os.Stat(abs)
+		if statErr != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		if info.Size() == 0 || info.Size() > maxFileBytes {
+			continue
+		}
+		data, readErr := os.ReadFile(abs)
+		if readErr != nil {
+			continue
+		}
+		contents := string(data)
+		for _, tok := range tokens {
+			if strings.Contains(contents, tok) {
+				if !seen[rel] {
+					seen[rel] = true
+					callers = append(callers, rel)
+				}
+				break
+			}
+		}
+	}
+	sort.Strings(callers)
+	return callers, nil
+}
+
+var binaryExts = map[string]bool{
+	".png": true, ".jpg": true, ".jpeg": true, ".gif": true, ".pdf": true,
+	".zip": true, ".tar": true, ".gz": true, ".ico": true, ".woff": true,
+	".woff2": true, ".ttf": true, ".otf": true, ".mp4": true, ".webm": true,
+	".wasm": true, ".exe": true, ".dll": true, ".so": true, ".dylib": true,
+	".db": true, ".sqlite": true, ".bin": true,
+}
+
+func isTextFileCandidate(rel string) bool {
+	ext := strings.ToLower(filepath.Ext(rel))
+	return !binaryExts[ext]
+}

--- a/cli/internal/codemap/importgraph_test.go
+++ b/cli/internal/codemap/importgraph_test.go
@@ -1,0 +1,76 @@
+package codemap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, root, rel, contents string) {
+	t.Helper()
+	abs := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(abs), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(abs, []byte(contents), 0644); err != nil {
+		t.Fatalf("write %s: %v", abs, err)
+	}
+}
+
+func TestDeriveCallers_FindsImports(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "web/renderer/html.ts", "export function render() {}\n")
+	writeFile(t, dir, "api/caller.ts",
+		"import { render } from '../web/renderer/html';\nrender();\n")
+	writeFile(t, dir, "api/unrelated.ts", "console.log('hi');\n")
+
+	callers, err := DeriveCallers(dir, []string{"web/renderer/html.ts"})
+	if err != nil {
+		t.Fatalf("DeriveCallers: %v", err)
+	}
+	if !contains(callers, "api/caller.ts") {
+		t.Errorf("expected api/caller.ts in callers, got %v", callers)
+	}
+	if contains(callers, "api/unrelated.ts") {
+		t.Errorf("unrelated file should not be a caller, got %v", callers)
+	}
+	if contains(callers, "web/renderer/html.ts") {
+		t.Errorf("target file should not be its own caller, got %v", callers)
+	}
+}
+
+func TestDeriveCallers_EmptyTargets(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.ts", "hello\n")
+	callers, err := DeriveCallers(dir, nil)
+	if err != nil {
+		t.Fatalf("DeriveCallers: %v", err)
+	}
+	if len(callers) != 0 {
+		t.Errorf("expected no callers for empty targets, got %v", callers)
+	}
+}
+
+func TestDeriveCallers_MatchesExtensionlessImports(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "pkg/util/format.go", "package util\n")
+	writeFile(t, dir, "cmd/main.go",
+		"package main\nimport _ \"example.com/app/pkg/util/format\"\n")
+
+	callers, err := DeriveCallers(dir, []string{"pkg/util/format.go"})
+	if err != nil {
+		t.Fatalf("DeriveCallers: %v", err)
+	}
+	if !contains(callers, "cmd/main.go") {
+		t.Errorf("expected extensionless match to find cmd/main.go, got %v", callers)
+	}
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/content/render.go
+++ b/cli/internal/content/render.go
@@ -42,8 +42,10 @@ func renderNode(b *strings.Builder, n *store.Node, children map[int64][]*store.N
 		b.WriteString(strings.Repeat("#", n.Level))
 		b.WriteString(" ")
 		b.WriteString(n.Content)
-		b.WriteString("\n")
-		renderChildren(b, n.ID, children, depth)
+		b.WriteString("\n\n")
+		for _, c := range children[n.ID] {
+			renderNode(b, c, children, depth)
+		}
 
 	case "paragraph":
 		b.WriteString(n.Content)
@@ -57,12 +59,12 @@ func renderNode(b *strings.Builder, n *store.Node, children map[int64][]*store.N
 				b.WriteString("- ")
 				b.WriteString(c.Content)
 				b.WriteString("\n")
-				// nested lists are children of the list_item
 				for _, sub := range children[c.ID] {
 					renderNode(b, sub, children, depth+1)
 				}
 			}
 		}
+		b.WriteString("\n")
 
 	case "ordered_list":
 		for i, c := range children[n.ID] {
@@ -74,6 +76,7 @@ func renderNode(b *strings.Builder, n *store.Node, children map[int64][]*store.N
 				}
 			}
 		}
+		b.WriteString("\n")
 
 	case "checklist":
 		for _, c := range children[n.ID] {
@@ -83,6 +86,7 @@ func renderNode(b *strings.Builder, n *store.Node, children map[int64][]*store.N
 				b.WriteString("\n")
 			}
 		}
+		b.WriteString("\n")
 
 	case "table":
 		kids := children[n.ID]
@@ -101,6 +105,7 @@ func renderNode(b *strings.Builder, n *store.Node, children map[int64][]*store.N
 				b.WriteString(" |\n")
 			}
 		}
+		b.WriteString("\n")
 
 	case "code_block":
 		lang, code := parseCodeContent(n.Content)
@@ -108,7 +113,7 @@ func renderNode(b *strings.Builder, n *store.Node, children map[int64][]*store.N
 		b.WriteString(lang)
 		b.WriteString("\n")
 		b.WriteString(code)
-		b.WriteString("\n```\n")
+		b.WriteString("\n```\n\n")
 
 	case "blockquote":
 		var inner strings.Builder
@@ -120,25 +125,13 @@ func renderNode(b *strings.Builder, n *store.Node, children map[int64][]*store.N
 			b.WriteString(line)
 			b.WriteString("\n")
 		}
+		b.WriteString("\n")
 
 	default:
 		if n.Content != "" {
 			b.WriteString(n.Content)
 			b.WriteString("\n\n")
 		}
-	}
-}
-
-// renderChildren renders children of a container node, adding a blank line
-// before the first child if there are any (used for headings).
-func renderChildren(b *strings.Builder, parentID int64, children map[int64][]*store.Node, depth int) {
-	kids := children[parentID]
-	if len(kids) == 0 {
-		return
-	}
-	b.WriteString("\n")
-	for _, c := range kids {
-		renderNode(b, c, children, depth)
 	}
 }
 

--- a/cli/internal/content/render_test.go
+++ b/cli/internal/content/render_test.go
@@ -159,6 +159,36 @@ func TestRender_Blockquote(t *testing.T) {
 	}
 }
 
+// TestRender_SiblingHeadingsHaveBlankLine guards against the regression
+// where two top-level headings emitted without a blank line between them
+// (e.g. an H1 with no body followed by H2 sections).
+func TestRender_SiblingHeadingsHaveBlankLine(t *testing.T) {
+	nodes := []*store.Node{
+		rootNode(1, "heading", 1, 0, "Title"),
+		rootNode(2, "heading", 2, 1, "Goal"),
+		childNode(3, 2, "paragraph", 0, 0, "Body."),
+	}
+	want := "# Title\n\n## Goal\n\nBody.\n"
+	if got := RenderMarkdown(nodes); got != want {
+		t.Errorf("got:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+// TestRender_BlockToHeading guards against a list/table/code_block being
+// directly abutted to a following heading.
+func TestRender_BlockToHeading(t *testing.T) {
+	nodes := []*store.Node{
+		rootNode(1, "heading", 2, 0, "A"),
+		childNode(2, 1, "list", 0, 0, ""),
+		childNode(3, 2, "list_item", 0, 0, "x"),
+		rootNode(4, "heading", 2, 1, "B"),
+	}
+	want := "## A\n\n- x\n\n## B\n"
+	if got := RenderMarkdown(nodes); got != want {
+		t.Errorf("got:\n%q\nwant:\n%q", got, want)
+	}
+}
+
 func TestRender_NestedList(t *testing.T) {
 	nodes := []*store.Node{
 		rootNode(1, "list", 0, 0, ""),

--- a/cli/main.go
+++ b/cli/main.go
@@ -109,7 +109,19 @@ func run(argv []string, w io.Writer) error {
 		return runGit(opts, config.ProjectDir(c3Dir), c3Dir, w)
 	}
 	if opts.Command == "verify" {
-		return cmd.RunVerify(cmd.VerifyOptions{C3Dir: c3Dir, JSON: opts.JSON, IncludeADR: opts.IncludeADR, Only: opts.Only}, w)
+		only := opts.Only
+		if opts.OnlyTouched {
+			touched, err := cmd.ResolveTouchedTargets(config.ProjectDir(c3Dir), c3Dir, opts.Since)
+			if err != nil {
+				return fmt.Errorf("--only-touched: %w", err)
+			}
+			if len(touched) == 0 {
+				fmt.Fprintln(w, "No touched entities since reference; nothing to verify.")
+				return nil
+			}
+			only = append(only, touched...)
+		}
+		return cmd.RunVerify(cmd.VerifyOptions{C3Dir: c3Dir, JSON: opts.JSON, IncludeADR: opts.IncludeADR, Only: only}, w)
 	}
 	if opts.Command == "repair" {
 		return cmd.RunRepair(cmd.RepairOptions{C3Dir: c3Dir, JSON: opts.JSON, IncludeADR: opts.IncludeADR, Only: opts.Only}, w)
@@ -123,14 +135,21 @@ func run(argv []string, w io.Writer) error {
 	hasCanonical := hasCanonicalDocs(c3Dir)
 	skipPreHeal := (opts.Command == "sync" && len(opts.Args) >= 1 && opts.Args[0] == "export") ||
 		opts.Command == "migrate"
+	mutates := commandMutatesCanonical(opts)
 
 	// v9 workflow treats canonical .c3/ markdown as submitted truth.
-	// When canonical files exist, verify first, then repair recoverable drift
-	// automatically before dispatching the requested command.
+	// Verify checks sync; for mutating commands we auto-repair recoverable
+	// drift. Read-only commands MUST NOT mutate canonical — the user edited
+	// those files and silent "repair" overwrites in-flight work. If verify
+	// trips on a read-only command, warn once and proceed with best-effort.
 	if hasCanonical && !skipPreHeal {
 		if err := cmd.RunVerify(cmd.VerifyOptions{C3Dir: c3Dir, JSON: opts.JSON, IncludeADR: opts.IncludeADR, Only: opts.Only}, io.Discard); err != nil {
-			if repairErr := cmd.RunRepair(cmd.RepairOptions{C3Dir: c3Dir, JSON: opts.JSON, IncludeADR: opts.IncludeADR, Only: opts.Only}, io.Discard); repairErr != nil {
-				return fmt.Errorf("error: auto-repair failed before %q: %w\noriginal verification error: %v", opts.Command, repairErr, err)
+			if mutates {
+				if repairErr := cmd.RunRepair(cmd.RepairOptions{C3Dir: c3Dir, JSON: opts.JSON, IncludeADR: opts.IncludeADR, Only: opts.Only}, io.Discard); repairErr != nil {
+					return fmt.Errorf("error: auto-repair failed before %q: %w\noriginal verification error: %v", opts.Command, repairErr, err)
+				}
+			} else {
+				fmt.Fprintln(os.Stderr, "warning: .c3/ drift detected; run 'c3x repair' to reconcile")
 			}
 		}
 		hasDB = fileExists(dbPath)
@@ -141,7 +160,7 @@ func run(argv []string, w io.Writer) error {
 	}
 
 	var rollback *mutationSnapshot
-	if commandMutatesCanonical(opts) {
+	if mutates {
 		rollback, err = newMutationSnapshot(c3Dir)
 		if err != nil {
 			return fmt.Errorf("error: create mutation rollback snapshot: %w", err)
@@ -358,6 +377,8 @@ func runCommand(opts cmd.Options, s *store.Store, c3Dir string, w io.Writer) err
 			C3Dir:      c3Dir,
 			IncludeADR: opts.IncludeADR,
 			Fix:        opts.Fix,
+			Only:       opts.Only,
+			Rules:      opts.Rules,
 		}, w)
 	case "read":
 		entityID := ""
@@ -446,6 +467,18 @@ func runCommand(opts cmd.Options, s *store.Store, c3Dir string, w io.Writer) err
 		err = cmd.RunImpact(cmd.ImpactOptions{
 			Store: s, EntityID: entityID, Depth: opts.Depth, JSON: opts.JSON,
 			IncludeCode: opts.IncludeCode, ProjectDir: projectDir,
+		}, w)
+	case "adr":
+		if !opts.FromDiff {
+			return fmt.Errorf("error: c3x adr requires --from-diff\nhint: c3x adr --from-diff [<slug>] [--since <ref>]")
+		}
+		slug := ""
+		if len(opts.Args) >= 1 {
+			slug = opts.Args[0]
+		}
+		err = cmd.RunAdrFromDiff(cmd.AdrFromDiffOptions{
+			Store: s, C3Dir: c3Dir, ProjectDir: projectDir,
+			Slug: slug, Since: opts.Since,
 		}, w)
 	case "export":
 		outputDir := c3Dir
@@ -549,7 +582,7 @@ func runCommand(opts cmd.Options, s *store.Store, c3Dir string, w io.Writer) err
 
 func commandMutatesCanonical(opts cmd.Options) bool {
 	switch opts.Command {
-	case "write", "add", "set", "wire", "unwire", "codemap":
+	case "write", "add", "set", "wire", "unwire":
 		return true
 	case "delete":
 		return !opts.DryRun

--- a/cli/main.go
+++ b/cli/main.go
@@ -138,11 +138,8 @@ func run(argv []string, w io.Writer) error {
 		opts.Command == "migrate"
 	mutates := commandMutatesCanonical(opts)
 
-	// v9 workflow treats canonical .c3/ markdown as submitted truth.
-	// Verify checks sync; for mutating commands we auto-repair recoverable
-	// drift. Read-only commands MUST NOT mutate canonical — the user edited
-	// those files and silent "repair" overwrites in-flight work. If verify
-	// trips on a read-only command, warn once and proceed with best-effort.
+	// Read-only commands must not mutate canonical: the user may be
+	// mid-edit and silent auto-repair overwrites their work.
 	if hasCanonical && !skipPreHeal {
 		if err := cmd.RunVerify(cmd.VerifyOptions{C3Dir: c3Dir, JSON: opts.JSON, IncludeADR: opts.IncludeADR, Only: opts.Only}, io.Discard); err != nil {
 			if mutates {

--- a/cli/main.go
+++ b/cli/main.go
@@ -443,7 +443,10 @@ func runCommand(opts cmd.Options, s *store.Store, c3Dir string, w io.Writer) err
 		if len(opts.Args) >= 1 {
 			entityID = opts.Args[0]
 		}
-		err = cmd.RunImpact(cmd.ImpactOptions{Store: s, EntityID: entityID, Depth: opts.Depth, JSON: opts.JSON}, w)
+		err = cmd.RunImpact(cmd.ImpactOptions{
+			Store: s, EntityID: entityID, Depth: opts.Depth, JSON: opts.JSON,
+			IncludeCode: opts.IncludeCode, ProjectDir: projectDir,
+		}, w)
 	case "export":
 		outputDir := c3Dir
 		if len(opts.Args) >= 1 {

--- a/cli/main.go
+++ b/cli/main.go
@@ -116,7 +116,8 @@ func run(argv []string, w io.Writer) error {
 				return fmt.Errorf("--only-touched: %w", err)
 			}
 			if len(touched) == 0 {
-				fmt.Fprintln(w, "No touched entities since reference; nothing to verify.")
+				fmt.Fprintln(w, "No touched entities. Widen scope: c3x verify --only-touched --since main")
+				fmt.Fprintln(w, "Or drop --only-touched for a full verify.")
 				return nil
 			}
 			only = append(only, touched...)

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -177,32 +177,35 @@ func TestRun_ListRebuildsMissingDatabaseFromCanonicalFiles(t *testing.T) {
 	}
 }
 
-func TestRun_ListSelfHealsBrokenSeal(t *testing.T) {
+func TestRun_ListDoesNotOverwriteCanonicalEdit(t *testing.T) {
 	c3Dir := setupRichC3DB(t)
 	if err := run([]string{"--c3-dir", c3Dir, "sync", "export", c3Dir}, &bytes.Buffer{}); err != nil {
 		t.Fatal(err)
 	}
 
 	readme := filepath.Join(c3Dir, "README.md")
-	data, err := os.ReadFile(readme)
+	orig, err := os.ReadFile(readme)
 	if err != nil {
 		t.Fatal(err)
 	}
-	data = bytes.Replace(data, []byte("## Goal\n\nTest."), []byte("## Goal\n\nSelf healed."), 1)
-	if err := os.WriteFile(readme, data, 0o644); err != nil {
+	edited := bytes.Replace(orig, []byte("## Goal\n\nTest."), []byte("## Goal\n\nUser edit."), 1)
+	if err := os.WriteFile(readme, edited, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	var buf bytes.Buffer
 	if err := run([]string{"--c3-dir", c3Dir, "list", "--json"}, &buf); err != nil {
-		t.Fatalf("expected list to self-heal broken seal, got %v", err)
+		t.Fatalf("list should succeed even with drifted canonical, got %v", err)
+	}
+	after, err := os.ReadFile(readme)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, edited) {
+		t.Fatalf("list must not overwrite user edit:\nwant:\n%s\ngot:\n%s", edited, after)
 	}
 	if !strings.Contains(buf.String(), "c3-0") {
-		t.Fatalf("expected list output after self-heal, got %q", buf.String())
-	}
-	var verify bytes.Buffer
-	if err := run([]string{"--c3-dir", c3Dir, "verify"}, &verify); err != nil {
-		t.Fatalf("expected repaired canonical tree to verify, got %v\n%s", err, verify.String())
+		t.Fatalf("expected list output, got %q", buf.String())
 	}
 }
 
@@ -527,17 +530,16 @@ func TestRun_CommandsSelfHealBrokenCanonicalPreverify(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Read-only commands must NOT mutate canonical. They warn and proceed.
 	if err := run([]string{"--c3-dir", c3Dir, "list"}, &bytes.Buffer{}); err != nil {
-		t.Fatalf("read-only command should self-heal broken canonical docs, got %v", err)
+		t.Fatalf("read-only command should proceed despite broken canonical, got %v", err)
 	}
-
-	data, err = os.ReadFile(readmePath)
+	postRead, err := os.ReadFile(readmePath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	broken = strings.Replace(string(data), "c3-seal:", "c3-seal: broken-", 1)
-	if err := os.WriteFile(readmePath, []byte(broken), 0644); err != nil {
-		t.Fatal(err)
+	if string(postRead) != broken {
+		t.Fatalf("read-only command must not mutate canonical; got diff:\nbefore:\n%s\nafter:\n%s", broken, string(postRead))
 	}
 
 	body := "Updated through section repair.\n"
@@ -925,6 +927,88 @@ func TestRun_WireRemoveFlag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+// TestRun_ReadOnlyCommandsAreIdempotent asserts read/lookup/impact/query/list
+// do not mutate any canonical .c3/ file, even when drift exists.
+func TestRun_ReadOnlyCommandsAreIdempotent(t *testing.T) {
+	c3Dir := setupRichC3DB(t)
+	if err := run([]string{"--c3-dir", c3Dir, "sync", "export", c3Dir}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Introduce drift by breaking a seal.
+	readmePath := filepath.Join(c3Dir, "README.md")
+	orig, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	broken := strings.Replace(string(orig), "c3-seal:", "c3-seal: broken-", 1)
+	if err := os.WriteFile(readmePath, []byte(broken), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Snapshot the whole .c3/ tree.
+	before := snapshotDir(t, c3Dir)
+
+	readOnly := [][]string{
+		{"list"},
+		{"read", "c3-0"},
+		{"query", "api"},
+		{"impact", "ref-jwt"},
+		{"lookup", "nonexistent/path.ts"},
+		{"graph", "c3-0"},
+		{"status"},
+		{"codemap"},
+		{"schema", "component"},
+	}
+	for _, args := range readOnly {
+		full := append([]string{"--c3-dir", c3Dir}, args...)
+		if err := run(full, &bytes.Buffer{}); err != nil {
+			// Some may legitimately error (e.g. nonexistent lookup) — that's fine.
+			// What matters is they don't mutate canonical.
+			_ = err
+		}
+	}
+
+	after := snapshotDir(t, c3Dir)
+	for path, beforeHash := range before {
+		if path == filepath.Join(c3Dir, "c3.db") {
+			continue // DB is the local cache, allowed to change
+		}
+		if afterHash, ok := after[path]; !ok {
+			t.Errorf("canonical file disappeared: %s", path)
+		} else if afterHash != beforeHash {
+			t.Errorf("canonical file mutated by read-only command: %s", path)
+		}
+	}
+	for path := range after {
+		if _, ok := before[path]; !ok && path != filepath.Join(c3Dir, "c3.db") {
+			t.Errorf("read-only commands created canonical file: %s", path)
+		}
+	}
+}
+
+func snapshotDir(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	if err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		out[path] = string(data)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return out
 }
 
 // setupC3DB creates a temp .c3/ dir with a SQLite DB containing a minimal fixture.


### PR DESCRIPTION
c3x impact previously returned only documented 'uses' citations, so a
target with 23 real callers but no citations reported "1". Agents trust
the narrow answer and skip sweep.

--include-code (off by default) merges the documented citation graph with
a grep-derived import graph over the target's code-map sources. Components
that call into the target but are not documented in .c3/ are flagged
[uncited]. Caller files with no owning component are surfaced separately
as codemap coverage gaps.

Heuristic: substring match on the target's relative path and its
extensionless form. Coarse enough to catch imports across Go/TS/JS/Py/Rust
without dialect parsing; false positives are flagged for review rather
than taken as truth.

JSON output changes from []ImpactResult to {entries, unmapped_files} so
callers can distinguish cited vs uncited and see coverage gaps.

https://claude.ai/code/session_011UPh867EvECMXGvhuGSEcs