### PR TITLE
fix(c3x): unwedge CLI when canonical drifts (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the C3 Skill plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- **Issue #79: `c3x` lockout when canonical drifts** — four wedge points unblocked:
+  - `c3x check` now surfaces the failing path/entity/message/hint instead of opaque `1 error(s)` (the validator output was being discarded by the dispatcher).
+  - Mutating commands (`add`, `set`, `wire`, `delete`, `write`) bypass canonical preverification per ADR `mutation-preverify-repair-bypass` — they refresh the cache without validating, so fix-path mutations can run against a wedged repo.
+  - `c3x repair` is now a real command that rebuilds the cache and reseals canonical. `RunRepair` already existed and `--help` documented it; only the dispatcher case was missing.
+  - `c3x wire <component> <adr-...>` is rejected with a clear message; ADR coverage belongs in the ADR's Affected Topology table, not in component `uses[]` frontmatter.
+
 ## [9.6.2] - 2026-04-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Mutating commands (`add`, `set`, `wire`, `delete`, `write`) bypass canonical preverification per ADR `mutation-preverify-repair-bypass` — they refresh the cache without validating, so fix-path mutations can run against a wedged repo.
   - `c3x repair` is now a real command that rebuilds the cache and reseals canonical. `RunRepair` already existed and `--help` documented it; only the dispatcher case was missing.
   - `c3x wire <component> <adr-...>` is rejected with a clear message; ADR coverage belongs in the ADR's Affected Topology table, not in component `uses[]` frontmatter.
+- **`c3x repair` now runs as a mutating command** — `commandMutatesCanonical` was returning false for `repair`, which meant the coordinator gate and rollback snapshot were skipped. A failed repair could leave `.c3/` partially rewritten with no way back.
+- **`c3x list --flat` honors `--json` and agent (`C3X_MODE=agent`) modes** — the flat path was an early return that bypassed the structured-output check. Existing JSON consumers and TOON-expecting agents got plain TSV instead.
+- **`c3x list --flat` third column is the canonical file path again** — it had been silently swapped to a duplicate of the entity ID, breaking scripts that rely on flat output to jump from entity to file.
+- **`c3x write` fails when relationship sync errors** — `syncRelationships` removes outbound edges before re-adding, so a typo in `uses`/`scope`/`sources` previously dropped relationships silently while the command exited successfully. Now returns an actionable error naming the bad target.
+- **`c3x write` is faithful to removed frontmatter fields** — `applyFrontmatter` now treats a full write as authoritative for `status`, `boundary`, `category`, `date`, `summary`, and `description`. Removing one of those fields from the piped frontmatter clears it in the DB instead of silently retaining the prior value (`title` keeps its conditional behavior since it has no body-derived fallback).
 
 ## [9.6.2] - 2026-04-24
 

--- a/cli/cmd/help.go
+++ b/cli/cmd/help.go
@@ -105,6 +105,24 @@ Options:
                      Errors if the rule has no citers. Composes with --only as union.`,
 	},
 	{
+		Name:     "repair",
+		OneLiner: "Rebuild local cache from canonical .c3/ and reseal",
+		Help: `Usage: c3x repair [--json] [--include-adr] [--only <id>]
+
+Rebuild the local C3 cache (.c3/c3.db) from canonical markdown, then re-export
+canonical files so seals match. Use after a branch switch, selective merge, or
+conflict resolution when 'c3x check' reports seal drift or cache divergence.
+
+Repair does not invent fixes for content errors — it only realigns the cache
+and seals to the current canonical text. If validation still fails afterwards,
+the canonical files themselves need editing.
+
+Options:
+  --json             Structured output
+  --include-adr      Include ADR entities in post-repair verification
+  --only <id>        Scope verification to specific entity IDs (repeatable)`,
+	},
+	{
 		Name:     "add",
 		Args:     "<type> <slug>",
 		OneLiner: "Create entity (auto-numbering + wiring)",

--- a/cli/cmd/list.go
+++ b/cli/cmd/list.go
@@ -37,12 +37,12 @@ type compactEntity struct {
 
 // RunList outputs the topology of entities from the store.
 func RunList(opts ListOptions, w io.Writer) error {
-	if opts.Flat {
-		return listFlat(opts.Store, opts.IncludeADR, w)
-	}
 	format := ResolveFormat(opts.JSONExplicit, isAgentMode())
 	if opts.JSON || format == FormatTOON {
 		return listStructured(opts, format, w)
+	}
+	if opts.Flat {
+		return listFlat(opts.Store, opts.IncludeADR, w)
 	}
 	return listTopology(opts.Store, opts.Compact, opts.IncludeADR, w)
 }
@@ -172,12 +172,18 @@ func listFlat(s *store.Store, includeADR bool, w io.Writer) error {
 		}
 		entities = filtered
 	}
+	parentSlug := map[string]string{}
+	for _, e := range entities {
+		if e.Type == "container" {
+			parentSlug[e.ID] = fmt.Sprintf("%s-%s", e.ID, e.Slug)
+		}
+	}
 	sort.Slice(entities, func(i, j int) bool {
 		return entities[i].ID < entities[j].ID
 	})
 
 	for _, e := range entities {
-		fmt.Fprintf(w, "%s\t%s\t%s\n", e.ID, e.Type, e.ID)
+		fmt.Fprintf(w, "%s\t%s\t%s\n", e.ID, e.Type, entityRelativePath(e, parentSlug))
 	}
 	return nil
 }

--- a/cli/cmd/list_test.go
+++ b/cli/cmd/list_test.go
@@ -147,6 +147,46 @@ func TestRunList_FlatIncludesADR(t *testing.T) {
 	}
 }
 
+// flat output must give id<TAB>type<TAB>canonical-path so scripts can jump
+// from an entity to its file. Printing the id twice loses the path column.
+func TestRunList_FlatThirdColumnIsCanonicalPath(t *testing.T) {
+	s := createDBFixture(t)
+	var buf bytes.Buffer
+
+	if err := RunList(ListOptions{Store: s, Flat: true}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		parts := strings.Split(line, "\t")
+		if len(parts) != 3 {
+			continue
+		}
+		id, third := parts[0], parts[2]
+		if third == id {
+			t.Errorf("third column must be the canonical path, got duplicated id %q in line %q", id, line)
+		}
+		if !strings.HasSuffix(third, ".md") {
+			t.Errorf("third column must point to a markdown file, got %q in line %q", third, line)
+		}
+	}
+}
+
+// --json must win over --flat: legacy JSON consumers depend on it.
+func TestRunList_FlatWithJSONReturnsJSON(t *testing.T) {
+	s := createDBFixture(t)
+	var buf bytes.Buffer
+
+	if err := RunList(ListOptions{Store: s, Flat: true, JSON: true}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	out := strings.TrimSpace(buf.String())
+	if !strings.HasPrefix(out, "[") && !strings.HasPrefix(out, "{") {
+		t.Errorf("--flat --json must emit JSON, got:\n%s", out)
+	}
+}
+
 func TestRunList_JSONExcludesADR(t *testing.T) {
 	s := createDBFixture(t)
 	var buf bytes.Buffer

--- a/cli/cmd/readwrite_test.go
+++ b/cli/cmd/readwrite_test.go
@@ -163,6 +163,56 @@ func TestRunWrite_ValidContent(t *testing.T) {
 	}
 }
 
+// A bad uses[] target must fail the whole write — syncRelationships removes
+// existing edges before re-adding, so a typo silently drops relationships
+// when the error is downgraded to a warning.
+func TestRunWrite_FailsOnRelationshipSyncError(t *testing.T) {
+	s := createRichDBFixture(t)
+	var buf bytes.Buffer
+
+	body := strictComponentBody("auth", "Updated authentication goal for API requests.")
+	content := "---\nid: c3-101\ntitle: auth\nuses:\n  - ref-does-not-exist\n---\n\n" + body
+
+	err := RunWrite(WriteOptions{Store: s, ID: "c3-101", Content: content}, &buf)
+	if err == nil {
+		t.Fatal("expected write to fail when uses[] references unknown entity")
+	}
+	if !strings.Contains(err.Error(), "ref-does-not-exist") {
+		t.Errorf("error must name the bad target, got: %v", err)
+	}
+}
+
+// A read|write round-trip must clear fields the user removed from frontmatter.
+// Otherwise old DB values resurface on the next read/export.
+func TestRunWrite_ClearsRemovedFrontmatterFields(t *testing.T) {
+	s := createRichDBFixture(t)
+	var buf bytes.Buffer
+
+	// Seed c3-101 with status + boundary set
+	e, _ := s.GetEntity("c3-101")
+	e.Status = "provisioned"
+	e.Boundary = "API edge"
+	if err := s.UpdateEntity(e); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write back a body with no status / boundary in frontmatter
+	body := strictComponentBody("auth", "Updated authentication goal for API requests.")
+	content := "---\nid: c3-101\ntitle: auth\n---\n\n" + body
+
+	if err := RunWrite(WriteOptions{Store: s, ID: "c3-101", Content: content}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	e, _ = s.GetEntity("c3-101")
+	if e.Status != "" {
+		t.Errorf("status must be cleared when removed from frontmatter, got %q", e.Status)
+	}
+	if e.Boundary != "" {
+		t.Errorf("boundary must be cleared when removed from frontmatter, got %q", e.Boundary)
+	}
+}
+
 func TestRunWrite_RejectsMissingSections(t *testing.T) {
 	s := createRichDBFixture(t)
 	var buf bytes.Buffer

--- a/cli/cmd/repair.go
+++ b/cli/cmd/repair.go
@@ -29,7 +29,7 @@ func RunVerify(opts VerifyOptions, w io.Writer) error {
 	if err := reportBrokenSeals(opts.C3Dir, opts.IncludeADR, opts.Only, w); err != nil {
 		return err
 	}
-	if err := ensureLocalCache(opts.C3Dir, opts.IncludeADR, opts.Only, w); err != nil {
+	if err := EnsureLocalCache(opts.C3Dir, opts.IncludeADR, opts.Only, w); err != nil {
 		return err
 	}
 	return runVerificationSuite(opts.C3Dir, opts.JSON, opts.IncludeADR, opts.Only, w)
@@ -52,7 +52,8 @@ func RunRepair(opts RepairOptions, w io.Writer) error {
 	return runVerificationSuite(opts.C3Dir, opts.JSON, opts.IncludeADR, opts.Only, w)
 }
 
-func ensureLocalCache(c3Dir string, includeADR bool, only []string, w io.Writer) error {
+// EnsureLocalCache refreshes .c3/c3.db from canonical without running validators.
+func EnsureLocalCache(c3Dir string, includeADR bool, only []string, w io.Writer) error {
 	dbPath := filepath.Join(c3Dir, "c3.db")
 	if !pathExists(dbPath) {
 		if err := RunImport(ImportOptions{C3Dir: c3Dir, SkipBackup: true, AllowADRDrift: !includeADR, Only: only}, io.Discard); err != nil {

--- a/cli/cmd/wire.go
+++ b/cli/cmd/wire.go
@@ -32,8 +32,12 @@ func RunWire(s *store.Store, sourceID, relationType, targetID string, w io.Write
 	if err != nil {
 		return fmt.Errorf("entity %q not found", sourceID)
 	}
-	if _, err := s.GetEntity(targetID); err != nil {
+	tgtEntity, err := s.GetEntity(targetID)
+	if err != nil {
 		return fmt.Errorf("entity %q not found", targetID)
+	}
+	if srcEntity.Type == "component" && tgtEntity.Type == "adr" {
+		return fmt.Errorf("cannot cite adr from component %s: components cite refs and rules; track ADR coverage in the ADR's Affected Topology table", sourceID)
 	}
 
 	// Add relationship in the store

--- a/cli/cmd/wire_test.go
+++ b/cli/cmd/wire_test.go
@@ -279,3 +279,32 @@ func TestRunUnwire_UpdatesNodeTree(t *testing.T) {
 		t.Errorf("node tree should not contain unwired ref, got: %s", rendered)
 	}
 }
+
+// Wiring an ADR onto a component must be rejected so ADR ids never land in
+// component frontmatter uses[]. Components govern by refs+rules; ADRs sit
+// elsewhere in the topology and are tracked via Affected Topology.
+func TestRunWire_RejectsADROnComponent(t *testing.T) {
+	s := createRichDBFixture(t)
+	if err := s.InsertEntity(&store.Entity{
+		ID: "adr-20260501-test", Type: "adr", Title: "test",
+		Slug: "test", Status: "implemented", Metadata: "{}",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err := RunWire(s, "c3-101", "cite", "adr-20260501-test", &buf)
+	if err == nil {
+		t.Fatal("expected wire of component->adr to be rejected")
+	}
+	if !strings.Contains(err.Error(), "adr") {
+		t.Errorf("error must explain ADR rejection, got: %v", err)
+	}
+
+	rels, _ := s.RelationshipsFrom("c3-101")
+	for _, r := range rels {
+		if r.ToID == "adr-20260501-test" {
+			t.Errorf("relationship must not be created on rejection, got: %+v", r)
+		}
+	}
+}

--- a/cli/cmd/write.go
+++ b/cli/cmd/write.go
@@ -74,7 +74,7 @@ func runWriteFull(existing *store.Entity, opts WriteOptions, w io.Writer) error 
 
 	if fm != nil {
 		if err := syncRelationships(opts.Store, opts.ID, fm); err != nil {
-			fmt.Fprintf(w, "warning: relationship sync: %v\n", err)
+			return fmt.Errorf("error: relationship sync for %s: %w", opts.ID, err)
 		}
 	}
 
@@ -141,29 +141,27 @@ func applyFrontmatter(e *store.Entity, fm *frontmatter.Frontmatter) {
 		return
 	}
 	metadata := parseMetadataMap(e.Metadata)
-	if fm.Goal != "" {
-		e.Goal = fm.Goal
-	}
-	if fm.Status != "" {
-		e.Status = fm.Status
-	}
-	if fm.Boundary != "" {
-		e.Boundary = fm.Boundary
-	}
-	if fm.Category != "" {
-		e.Category = fm.Category
-	}
+	// Authoritative on full write: removing a field from FM clears it.
+	// Goal stays restorable from the body via promoteGoalIfEmpty.
+	e.Goal = fm.Goal
+	e.Status = fm.Status
+	e.Boundary = fm.Boundary
+	e.Category = fm.Category
+	e.Date = fm.Date
+	// Title has no body-derived fallback — leave it alone when blank
+	// to avoid orphaning the entity from a truncated round-trip.
 	if fm.Title != "" {
 		e.Title = fm.Title
 	}
-	if fm.Date != "" {
-		e.Date = fm.Date
-	}
 	if fm.Summary != "" {
 		metadata["summary"] = fm.Summary
+	} else {
+		delete(metadata, "summary")
 	}
 	if fm.Description != "" {
 		metadata["description"] = fm.Description
+	} else {
+		delete(metadata, "description")
 	}
 	for key, value := range fm.Extra {
 		metadata[key] = value
@@ -323,7 +321,7 @@ func syncRelationships(s *store.Store, entityID string, fm *frontmatter.Frontmat
 		if err := s.AddRelationship(&store.Relationship{
 			FromID: entityID, ToID: key.toID, RelType: key.relType,
 		}); err != nil {
-			errs = append(errs, err.Error())
+			errs = append(errs, fmt.Sprintf("%s -> %s (%s): %v", entityID, key.toID, key.relType, err))
 		}
 	}
 	if len(errs) > 0 {

--- a/cli/main.go
+++ b/cli/main.go
@@ -523,7 +523,7 @@ func runCommand(opts cmd.Options, s *store.Store, c3Dir string, stdin io.Reader,
 
 func commandMutatesCanonical(opts cmd.Options) bool {
 	switch opts.Command {
-	case "write", "add", "set", "wire", "delete":
+	case "write", "add", "set", "wire", "delete", "repair":
 		if opts.Command == "delete" {
 			return !opts.DryRun
 		}

--- a/cli/main.go
+++ b/cli/main.go
@@ -111,17 +111,15 @@ func runWithIO(argv []string, stdin io.Reader, stdinTerminal bool, w io.Writer, 
 		return runThroughCoordinator(argv, stdin, stdinTerminal, c3Dir, w, stderr)
 	}
 
-	// Read-only commands must not mutate canonical: the user may be
-	// mid-edit and silent auto-repair overwrites their work.
+	// Mutations bypass preverify (ADR mutation-preverify-repair-bypass): the
+	// mutation itself may be the fix.
 	if hasCanonical {
-		if err := cmd.RunVerify(cmd.VerifyOptions{C3Dir: c3Dir, JSON: opts.JSON, IncludeADR: opts.IncludeADR, Only: opts.Only}, io.Discard); err != nil {
-			if mutates {
-				if repairErr := cmd.RunRepair(cmd.RepairOptions{C3Dir: c3Dir, JSON: opts.JSON, IncludeADR: opts.IncludeADR, Only: opts.Only}, io.Discard); repairErr != nil {
-					return fmt.Errorf("error: auto-repair failed before %q: %w\noriginal verification error: %v", opts.Command, repairErr, err)
-				}
-			} else {
-				fmt.Fprintln(stderr, "warning: .c3/ drift detected; run 'c3x check' to reconcile")
+		if mutates {
+			if err := cmd.EnsureLocalCache(c3Dir, opts.IncludeADR, opts.Only, io.Discard); err != nil {
+				return fmt.Errorf("error: refresh cache before %q: %w", opts.Command, err)
 			}
+		} else if err := cmd.RunVerify(cmd.VerifyOptions{C3Dir: c3Dir, JSON: opts.JSON, IncludeADR: opts.IncludeADR, Only: opts.Only}, io.Discard); err != nil {
+			fmt.Fprintln(stderr, "warning: .c3/ drift detected; run 'c3x check' to reconcile")
 		}
 		hasDB = fileExists(dbPath)
 	}
@@ -429,7 +427,9 @@ func runCommand(opts cmd.Options, s *store.Store, c3Dir string, stdin io.Reader,
 	case "list":
 		err = cmd.RunList(cmd.ListOptions{Store: s, JSON: opts.JSON, Flat: opts.Flat, Compact: opts.Compact, C3Dir: c3Dir, IncludeADR: opts.IncludeADR, JSONExplicit: opts.JSONExplicit}, w)
 	case "check":
-		if err = cmd.RunVerify(cmd.VerifyOptions{C3Dir: c3Dir, JSON: opts.JSON, IncludeADR: opts.IncludeADR, Only: opts.Only}, io.Discard); err != nil {
+		var verifyOut bytes.Buffer
+		if err = cmd.RunVerify(cmd.VerifyOptions{C3Dir: c3Dir, JSON: opts.JSON, IncludeADR: opts.IncludeADR, Only: opts.Only}, &verifyOut); err != nil {
+			_, _ = io.Copy(w, &verifyOut)
 			return fmt.Errorf("%w\nhint: run c3x check again after resolving", err)
 		}
 		err = cmd.RunCheckV2(cmd.CheckOptions{
@@ -506,6 +506,8 @@ func runCommand(opts cmd.Options, s *store.Store, c3Dir string, stdin io.Reader,
 			id = opts.Args[0]
 		}
 		err = cmd.RunDelete(cmd.DeleteOptions{C3Dir: c3Dir, ID: id, Store: s, DryRun: opts.DryRun}, w)
+	case "repair":
+		err = cmd.RunRepair(cmd.RepairOptions{C3Dir: c3Dir, JSON: opts.JSON, IncludeADR: opts.IncludeADR, Only: opts.Only}, w)
 	default:
 		return fmt.Errorf("error: unknown command '%s'\nhint: run 'c3x --help' to see available commands", opts.Command)
 	}

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -236,6 +236,104 @@ func TestRun_CheckWithDB(t *testing.T) {
 	_ = run([]string{"--c3-dir", c3Dir, "check", "--json"}, &buf)
 }
 
+// check must surface the failing entity + message, not just "1 error(s)".
+func TestRun_CheckSurfacesValidatorIssues(t *testing.T) {
+	c3Dir := setupRichC3DB(t)
+	seedCanonicalReadme(t, c3Dir)
+
+	// Break c3-101 by stripping its strict body so check returns errors with details.
+	s, err := store.Open(filepath.Join(c3Dir, "c3.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := content.WriteEntity(s, "c3-101", "# auth\n\n## Goal\n\nThin.\n"); err != nil {
+		s.Close()
+		t.Fatal(err)
+	}
+	if err := cmd.RunSyncExport(cmd.ExportOptions{Store: s, OutputDir: c3Dir}, io.Discard); err != nil {
+		s.Close()
+		t.Fatal(err)
+	}
+	s.Close()
+
+	var buf bytes.Buffer
+	err = run([]string{"--c3-dir", c3Dir, "check"}, &buf)
+	if err == nil {
+		t.Fatal("expected check to fail on broken c3-101 body")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "c3-101") {
+		t.Errorf("check output must name the failing entity, got:\n%s", out)
+	}
+	if !strings.Contains(out, "missing required section") && !strings.Contains(out, "empty required section") {
+		t.Errorf("check output must describe what failed, got:\n%s", out)
+	}
+}
+
+// check --json must include the issue list with entity + message.
+func TestRun_CheckJSONIncludesIssues(t *testing.T) {
+	c3Dir := setupRichC3DB(t)
+	seedCanonicalReadme(t, c3Dir)
+
+	s, err := store.Open(filepath.Join(c3Dir, "c3.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := content.WriteEntity(s, "c3-101", "# auth\n\n## Goal\n\nThin.\n"); err != nil {
+		s.Close()
+		t.Fatal(err)
+	}
+	if err := cmd.RunSyncExport(cmd.ExportOptions{Store: s, OutputDir: c3Dir}, io.Discard); err != nil {
+		s.Close()
+		t.Fatal(err)
+	}
+	s.Close()
+
+	var buf bytes.Buffer
+	err = run([]string{"--c3-dir", c3Dir, "check", "--json"}, &buf)
+	if err == nil {
+		t.Fatal("expected check --json to fail")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "c3-101") {
+		t.Errorf("check --json must include entity id, got:\n%s", out)
+	}
+	if !strings.Contains(out, "\"issues\"") && !strings.Contains(out, "issues:") {
+		t.Errorf("check --json must include issues list, got:\n%s", out)
+	}
+}
+
+// Mutations must not be gated by canonical preverify failures, per ADR
+// mutation-preverify-repair-bypass — the mutation itself may be the fix.
+func TestRun_MutationBypassesPreverify(t *testing.T) {
+	c3Dir := setupRichC3DB(t)
+	seedCanonicalReadme(t, c3Dir)
+
+	c101Path := filepath.Join(c3Dir, "c3-1-api", "c3-101-auth.md")
+	broken := "---\nid: c3-101\nc3-seal: deadbeef\ntitle: auth\ntype: component\ncategory: foundation\nparent: c3-1\n---\n\n# auth\n\n## Goal\n\nThin.\n"
+	if err := os.WriteFile(c101Path, []byte(broken), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err := run([]string{"--c3-dir", c3Dir, "set", "c3-0", "goal", "Updated despite drift"}, &buf)
+	if err != nil {
+		t.Fatalf("mutation must bypass preverify, got: %v", err)
+	}
+}
+
+// c3x repair must be a real command, not "unknown command".
+func TestRun_RepairCommandExists(t *testing.T) {
+	c3Dir := setupRichC3DB(t)
+	seedCanonicalReadme(t, c3Dir)
+
+	var buf bytes.Buffer
+	err := run([]string{"--c3-dir", c3Dir, "repair"}, &buf)
+	if err != nil && strings.Contains(err.Error(), "unknown command") {
+		t.Fatalf("c3x repair must be wired up, got: %v", err)
+	}
+}
+
 func TestRun_Schema(t *testing.T) {
 	c3Dir := setupC3DB(t)
 	var buf bytes.Buffer

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -334,6 +334,15 @@ func TestRun_RepairCommandExists(t *testing.T) {
 	}
 }
 
+// repair rewrites canonical files and the cache, so it must classify as mutating
+// (gives it the rollback snapshot + coordinator gate). Otherwise a failed
+// repair can leave .c3/ partially rewritten with no way back.
+func TestCommandMutatesCanonical_RepairIsMutating(t *testing.T) {
+	if !commandMutatesCanonical(cmd.Options{Command: "repair"}) {
+		t.Fatal("repair must be classified as mutating: it rewrites canonical files")
+	}
+}
+
 func TestRun_Schema(t *testing.T) {
 	c3Dir := setupC3DB(t)
 	var buf bytes.Buffer


### PR DESCRIPTION
Closes #79.

Re-targeted to `dev` (was originally PR #80 against `main`). Same two commits, rebased onto current dev tip; tests green on this base.

## Summary

Four wedge points in v9.6.2 left `c3x` unrecoverable when any single entity failed validation. The first commit fixes them; the second addresses a Codex review pass.

| # | Bug | Root cause | Fix |
|---|-----|-----------|-----|
| 1 | `check failed: 1 error(s)` with no detail | dispatcher's `case "check"` passed `io.Discard` to `RunVerify` | capture into a buffer; dump on error |
| 2 | every mutation gated by failing auto-repair | `runWithIO` ran `RunVerify`+`RunRepair` before mutations | mutations call `EnsureLocalCache` (refresh-only, no validators) per ADR `mutation-preverify-repair-bypass` |
| 3 | `c3x repair` returned `unknown command` | dispatcher case missing | wire it in `runCommand` switch + register in `Commands` |
| 4 | wire produced `uses[]` with ADR ids on components | no rejection at write time | reject `RunWire` when src=component, tgt=adr |

Codex review pass picked up additional pre-existing issues (the user asked to bundle them):

- **`repair` was not classified as mutating** — skipped coordinator gate + rollback snapshot, so a failed repair could leave `.c3/` partially rewritten.
- **`list --flat` ignored `--json` and agent mode** — early return bypassed `ResolveFormat`; existing JSON/TOON consumers got TSV.
- **`list --flat` third column was a duplicate id, not the canonical path** — broke scripts that jump from entity to file.
- **`write` downgraded relationship-sync errors to warnings** — `syncRelationships` removes outbound edges before re-adding, so a typo silently dropped relationships.
- **`write` ignored removed frontmatter fields** — `applyFrontmatter` only copied non-empty values, so a `read | edit | write` round-trip wasn't faithful for `status`, `boundary`, `summary`, etc.

## Test plan

10 regression tests added across `cli/main_test.go`, `cli/cmd/wire_test.go`, `cli/cmd/list_test.go`, `cli/cmd/readwrite_test.go`. All pass; full `go test ./...` clean.

End-to-end repro from the issue verified manually:

- `c3x check` against drifted canonical now prints `BROKEN_SEAL <path>` with hint
- `c3x set c3-0 goal "..."` succeeds against the same drift state
- `c3x repair` rebuilds + reseals + reports remaining content issues with full detail
- `c3x wire c3-101 adr-...` rejected with: `cannot cite adr from component c3-101: components cite refs and rules; track ADR coverage in the ADR's Affected Topology table`