### PR TITLE
fix(npm): declare repository for provenance

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,11 @@
   "version": "11.1.1",
   "description": "Thin CLI client for c3x — architecture documentation tool",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lagz0ne/c3-skill.git",
+    "directory": "packages/cli"
+  },
   "bin": {
     "c3x": "dist/cli.mjs"
   },


### PR DESCRIPTION
## Summary
- Add normalized repository metadata to packages/cli/package.json so npm provenance can validate the trusted publishing source repository.

## Verification
- npm test
- npm publish --dry-run --json
- git diff --check
- C3X_MODE=agent bash skills/c3/bin/c3x.sh check

The previous release workflow run reached trusted publishing and signed provenance, then npm rejected the package because repository.url was missing.