### PR TITLE
docs: update README for current C3 runtime model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # C3: Architecture That Agents Can Read — and Change Safely
 
-C3 gives your codebase an architecture model an LLM can navigate, query, and change **without breaking it**. The model is a sealed `.c3/` tree of markdown — reviewable in Git, validated by machine. (`c3.db` is just a local cache the CLI rebuilds at any time; never merge it.)
+C3 gives your codebase an architecture model an LLM can navigate, query, evaluate, and change **without breaking it**. The model is a sealed `.c3/` tree of markdown — reviewable in Git, validated by machine. (`c3.db` is just a local cache the CLI rebuilds at any time; never merge it.)
 
 One model, three acts:
 
@@ -12,8 +12,9 @@ The point of the freeze is Act 2: because facts only move through change-units, 
 
 - **Membership writes itself.** Set a child's `parent:` and the parent's membership table grows the row — synthesized, never hand-authored, always in sync.
 - **The destruction gate refuses strays.** A retire that would orphan a live child or dangle a live citation is **refused** — unless the same change-unit also reparents or retires it. The graph never strands.
-- **The inspection gate forces a look at the code.** Before a change to a code-bound fact lands, `c3x change inspect` surfaces what the doc now claims; `*.inspect.md` must attest, citing a real file in the fact's territory — no rubber stamps.
-- **Rebase resolves conflict.** When the code underneath a staged patch moves, `c3x change rebase` emits a drift bundle to re-author against the fresh anchor.
+- **Eval checks claims against reality.** `.c3/eval/*.yaml` binds facts to the code, files, or commands they govern. `c3x eval` produces one-off `holds` / `drift` / `needs_judgement` verdicts without turning a single LLM answer into truth.
+- **Search and lookup stay small.** `c3x search` finds concepts by semantic, keyword, and graph signal; `c3x lookup` maps files through eval bindings to owners, refs, and rules. Agent-mode output is TOON and tuned to keep the useful proof while dropping noise.
+- **Rebase resolves conflict.** When a staged patch's cited block moves, `c3x change rebase` emits a drift bundle to re-author against the fresh anchor.
 
 ## Install / Run
 
@@ -25,7 +26,7 @@ claude plugin install lagz0ne/c3-skill
 
 Then: `/c3 onboard this project`
 
-The repository and platform-neutral skill ZIP carry the skill, Claude plugin metadata, and wrapper only. On first real C3 command the wrapper delegates to the pinned `@c3x/cli` runtime manager, which downloads verified release assets into a local cache.
+The source repository, `main` branch, and platform-neutral skill ZIP carry the skill, Claude plugin metadata, and wrapper only — no committed `c3x-*` binaries. On first real C3 command the wrapper delegates to the pinned `@c3x/cli` runtime manager, which downloads verified release assets into a versioned local cache.
 
 **Fat skill ZIPs (self-contained):**
 
@@ -34,14 +35,18 @@ Use a per-platform release asset when the skill must run in a sandboxed or offli
 - `c3-skill-<os>-<arch>-v<version>.zip` is the full fat build. It carries the `c3x` binary and embedded semantic model/native ONNX runtime, and includes `.gitattributes` so Git preserves the bundled binary as binary content.
 - `c3-skill-linux-<arch>-portable-v<version>.zip` is the portable Linux fat build. It carries a bundled pure-Go `c3x` binary for broader distro/sandbox compatibility; semantic ONNX search is unavailable in that build, so search falls back to keyword/graph behavior.
 
+Fat ZIPs are GitHub Release artifacts, not files committed back to `main`.
+
 **`npx` CLI (thin, fetched on demand):**
 
 ```bash
 npx @c3x/cli check
 npx @c3x/cli search "how do users sign in and get permissions"
+npx @c3x/cli runtime versions
+npx @c3x/cli runtime use 11.4.0
 ```
 
-The npm package downloads the matching `c3x` binary and semantic model from the GitHub Release into a versioned local cache on first use.
+The npm package downloads the matching `c3x` binary and semantic model from the GitHub Release into a versioned local cache on first use. `npx @c3x/cli runtime use <version>` writes `.c3/runtime.json` with only the selected runtime version; it never stores a binary path or URL.
 
 ## What You Get
 
@@ -53,8 +58,32 @@ The npm package downloads the matching `c3x` binary and semantic model from the 
 | `/c3` create a ref for error handling | **ref** — a rationale-bearing fact other facts cite |
 | `/c3` add a rule for structured logging | **rule** — an enforceable standard with a golden example |
 | `/c3` edit the canvas for ADRs | **canvas** — reshape the definitions that govern your docs, or raise a rung |
+| `/c3` does the auth doc still match code? | **eval** — run deterministic gather/transform/verdict specs over the external state a fact governs |
 | `/c3` audit the docs | **audit** — is the sealed truth intact and consistent? ends in PASS / WARN / FAIL |
 | `/c3` what breaks if I change payments? | **sweep** — reverse-graph blast radius + whether the destruction gate will even let the change land |
+
+## Current CLI Shape
+
+The common read path is intentionally narrow:
+
+```bash
+c3x search "billing retries"
+c3x lookup 'cli/cmd/*.go'
+c3x read c3-108 --section Goal
+c3x graph c3-108 --format mermaid
+```
+
+Use `c3x check` for sealed-doc integrity and `c3x eval` for fact-vs-external conformance. They are separate on purpose: a frozen fact can be structurally valid while its governed code has drifted.
+
+The npm entrypoint adds a namespaced runtime manager so cache operations do not collide with project commands:
+
+```bash
+npx @c3x/cli runtime versions
+npx @c3x/cli runtime installed
+npx @c3x/cli runtime install latest
+npx @c3x/cli runtime use 11.4.0
+npx @c3x/cli runtime prune
+```
 
 The full command catalog, flags, and gate details live in the skill: read `skills/c3/SKILL.md`, or run `c3x --help` (the packaged CLI is authoritative).
 


### PR DESCRIPTION
## Summary
- update README for eval/search/lookup and current narrow agent read paths
- document the npm runtime manager and project runtime selection metadata
- make explicit that main/source and the no-binary skill do not carry committed c3x binaries; fat binaries live in GitHub Release artifacts

## Verification
- git diff --check
- C3X_MODE=agent bash skills/c3/bin/c3x.sh check
- C3X_MODE=agent bash skills/c3/bin/c3x.sh eval