### PR TITLE
fix(authoring): make the authoring surface tell the truth (#94, #111–#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,70 @@ All notable changes to the C3 Skill plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [11.7.0] - 2026-08-05
+
+Minor release: **make the authoring surface tell the truth.** Closes the seven issues filed
+against the change-unit workflow (#94, #111, #112, #113, #114, #115, #116) — a cluster whose common
+theme was a tool that validated late, reported the wrong cause, and silently rewrote what you wrote.
+
+### Fixed
+
+- **Stop destroying inline markup inside table cells** (#111). Cells were read through goldmark's
+  inline-text extraction, so backticks, `*emphasis*` and `[links](url)` were deleted from every
+  table cell on every write, and the re-rendered document persisted the loss. Cells now come from
+  their raw source span. Paragraphs were never affected.
+- **Make `\|` round-trip** (#112). An escaped pipe kept its backslash in the parsed cell value, so a
+  cite snippet taken from a table row — most of the corpus — could not be written into an Evidence
+  cell in any encoding: raw pipes broke the table, escaped pipes were reported as stale. Escapes are
+  now unescaped on parse and re-escaped on write, symmetrically.
+- **Say which half of a cite mismatched** (#111, #112, #114). "stale node hash or snippet" reported a
+  stale hash even when the hash was current and only the snippet differed — an affirmatively false
+  cause whose hint told you to refresh a handle that came back byte-identical. The two failures are
+  now separate messages: a snippet mismatch prints cited-vs-actual and says the snippet is optional.
+- **Point cite hints at the invocation that emits node handles** (#114). Every hint named
+  `c3x read <id> --cite`, which emits the entity-root handle the validator had just rejected. They
+  now name `--section <name> --cite`, and bare `--cite` additionally lists per-node handles.
+- **Report every failing row per submission** (#116). Row validation bailed at the first finding, so
+  one ADR took four submissions to surface four independently-detectable classes. Findings are now
+  collected in one pass; the only remaining skip is the genuine dependency (Evidence cannot be
+  checked against a target that does not resolve) and it is explicit.
+- **Name the offending row on a table-shape rejection** (#116). The parser knew the row number and
+  the expected-vs-actual cell counts; all four validators dropped it and reported only the section
+  name. The cause is now carried through.
+- **Route a missing cache to `repair`** (#115). A fresh `git worktree` has canonical `.c3/` but no
+  `c3.db`; the hint offered `check` and `init` and never `repair`. Reads now rebuild the cache on
+  demand — it is disposable and derivable, so there is nothing to decide — and the remaining
+  failure names `repair`.
+- **Name the bare id behind a decorated cell** (#94). An Entity cell like
+  `c3-3 shared (prompt.ts)` was interpolated whole as if it were an id. When the first token
+  resolves, the rejection now says so. (The panic this issue originally reported was already fixed;
+  a regression test now pins it.)
+
+### Added
+
+- **`--format text`** (#116). Agent-mode output flattens multi-line bodies onto one line with
+  literal `\n`, and the obvious shell fix (`tr '\\n' '\n'`) silently corrupts every literal `n`.
+  Text format emits real newlines. TOON remains the agent-mode default; this is opt-in.
+
+### Changed
+
+- **Document that After-cites go stale on apply** (#113). A change doc's Evidence anchors the block
+  its own unit rewrites, so applying the unit invalidates those cites — by design: the
+  `accepted → done` latch fires only when the refreshed cites resolve, which is what proves the
+  change landed. `change apply` now prints the targets it touched and the refresh step, and
+  `references/change.md` carries it as an explicit stage rather than stopping at `check`.
+- **Document node-id instability.** `#nNODE` in a handle is a lookup hint; the `sha256` is the
+  anchor. Ids renumber on a cache rebuild and resolution falls back to matching the hash, so
+  handles survive rebuilds and differ harmlessly between collaborators.
+
+### Migration
+
+The #111 fix changes a node's hash only for table cells whose markdown still carries inline markup
+on disk. Documents already written by an earlier version had that markup stripped, so re-parsing
+them is idempotent and their seals do not move — verified byte-identical on this repo. If your
+`.c3/` contains hand-authored table cells with backticks or emphasis, run `c3x repair` once and
+re-cite any Evidence handle the rebuild reports as stale.
+
 ## [11.6.3] - 2026-07-15
 
 Patch release: **make change-unit edge writes truthful and portable receipts independently verifiable.**

--- a/cli/cmd/add.go
+++ b/cli/cmd/add.go
@@ -215,9 +215,11 @@ func validateADRCreationBody(body string, defs ...schema.Canvas) []Issue {
 		}
 		table, err := markdown.ParseTable(content)
 		if err != nil {
+			// The parser already knows which row is malformed and by how many
+			// cells; report that instead of only the section name.
 			issues = append(issues, Issue{
 				Severity: "error",
-				Message:  fmt.Sprintf("invalid required table: %s", sectionDef.Name),
+				Message:  fmt.Sprintf("invalid required table: %s — %v", sectionDef.Name, err),
 				Hint:     fmt.Sprintf("use %s for the %s table columns", adrSchemaHint(), sectionDef.Name),
 			})
 			continue

--- a/cli/cmd/add.go
+++ b/cli/cmd/add.go
@@ -215,8 +215,6 @@ func validateADRCreationBody(body string, defs ...schema.Canvas) []Issue {
 		}
 		table, err := markdown.ParseTable(content)
 		if err != nil {
-			// The parser already knows which row is malformed and by how many
-			// cells; report that instead of only the section name.
 			issues = append(issues, Issue{
 				Severity: "error",
 				Message:  fmt.Sprintf("invalid required table: %s — %v", sectionDef.Name, err),

--- a/cli/cmd/adr_linkage.go
+++ b/cli/cmd/adr_linkage.go
@@ -196,46 +196,101 @@ func parseADRAffectedTopology(s *store.Store, body string, severity string, sche
 		entityID := strings.TrimSpace(row["Entity"])
 		targetType := strings.TrimSpace(row["Type"])
 		whyAffected := strings.TrimSpace(row["Why affected"])
+		evidence := strings.TrimSpace(row["Evidence"])
 		if isNARow(entityID) || isNARow(targetType) {
 			continue
 		}
-		if entityID == "" || targetType == "" {
+
+		// One pass per row: the cells fail independently, so collect every
+		// finding instead of bailing at the first. Bailing made a blank Why hide
+		// the row's Evidence defect, costing a submission round-trip per class.
+		var entity *store.Entity
+		rowResolved := true
+		switch {
+		case entityID == "" || targetType == "":
+			rowResolved = false
 			issues = append(issues, Issue{
 				Severity: severity,
 				Message:  "Affected Topology rows must include both Entity and Type, or use N.A - <reason>",
 				Hint:     "fill the Entity and Type cells for each affected topology row",
 			})
-			continue
+		default:
+			resolved, err := s.GetEntity(entityID)
+			if err != nil {
+				rowResolved = false
+				if bare := bareIDFromCell(s, entityID); bare != "" {
+					issues = append(issues, freeFormIDCellIssue("Affected Topology", "Entity", "Why affected", entityID, bare, severity))
+					break
+				}
+				issues = append(issues, Issue{
+					Severity: severity,
+					Message:  fmt.Sprintf("Affected Topology references unknown entity: %s", entityID),
+					Hint:     "use an existing c3-* ID, or change the row to N.A - <reason>",
+				})
+				break
+			}
+			entity = resolved
+			if resolved.Type != targetType {
+				rowResolved = false
+				issues = append(issues, Issue{
+					Severity: severity,
+					Message:  fmt.Sprintf("Affected Topology type mismatch: %s is %s, not %s", entityID, resolved.Type, targetType),
+					Hint:     "align the Type column with the referenced entity kind",
+				})
+			}
 		}
-		entity, err := s.GetEntity(entityID)
-		if err != nil {
-			issues = append(issues, Issue{
-				Severity: severity,
-				Message:  fmt.Sprintf("Affected Topology references unknown entity: %s", entityID),
-				Hint:     "use an existing c3-* ID, or change the row to N.A - <reason>",
-			})
-			continue
-		}
-		if entity.Type != targetType {
-			issues = append(issues, Issue{
-				Severity: severity,
-				Message:  fmt.Sprintf("Affected Topology type mismatch: %s is %s, not %s", entityID, entity.Type, targetType),
-				Hint:     "align the Type column with the referenced entity kind",
-			})
-			continue
-		}
+
 		if whyAffected == "" || isNARow(whyAffected) {
+			rowResolved = false
 			issues = append(issues, Issue{
 				Severity: severity,
 				Message:  fmt.Sprintf("Affected Topology row for %s must explain why it is affected", entityID),
 				Hint:     "fill the Why affected column with the concrete reason, or mark the entire row N.A - <reason>",
 			})
-			continue
 		}
-		issues = append(issues, validateADREvidence(s, "Affected Topology", entityID, strings.TrimSpace(row["Evidence"]), severity, false)...)
-		targets = append(targets, adrAffectedTarget{ID: entityID, Type: targetType})
+
+		// Deliberate dependency, not an early bail: the version/hash/snippet
+		// checks compare Evidence AGAINST the row target, so an Entity cell that
+		// did not resolve leaves only the cell-shape checks runnable.
+		if entity != nil {
+			issues = append(issues, validateADREvidence(s, "Affected Topology", entityID, evidence, severity, false)...)
+		} else {
+			_, shapeIssues := validateADREvidenceShape("Affected Topology", entityID, evidence, severity, false)
+			issues = append(issues, shapeIssues...)
+		}
+
+		if rowResolved {
+			targets = append(targets, adrAffectedTarget{ID: entityID, Type: targetType})
+		}
 	}
 	return targets, issues
+}
+
+// bareIDFromCell reports the first whitespace-separated token of an id cell when
+// that token resolves to a known entity — i.e. the author wrote a DECORATED cell
+// ("c3-3 shared (prompt.ts)") rather than naming something that does not exist.
+// Empty when the cell is a single token or nothing in it resolves, so the caller
+// keeps the plain unknown-target finding.
+func bareIDFromCell(s *store.Store, cell string) string {
+	fields := strings.Fields(cell)
+	if len(fields) < 2 {
+		return ""
+	}
+	if _, err := s.GetEntity(fields[0]); err != nil {
+		return ""
+	}
+	return fields[0]
+}
+
+// freeFormIDCellIssue names the id it found instead of interpolating the whole
+// cell as one. The old "unknown entity: c3-3 shared (prompt.ts)" sent authors
+// hunting for a missing entity when the real fix was to trim the cell.
+func freeFormIDCellIssue(sectionName, colName, proseCol, cell, bareID, severity string) Issue {
+	return Issue{
+		Severity: severity,
+		Message:  fmt.Sprintf("%s %s cell must contain only the bare id, got free-form text: %s", sectionName, colName, cell),
+		Hint:     fmt.Sprintf("use just %s in the %s cell and move the rest into %s", bareID, colName, proseCol),
+	}
 }
 
 func parseADRRelatedTable(s *store.Store, body, sectionName, colName, targetType, severity string, schemaCommand string) (map[string]bool, []Issue) {
@@ -251,78 +306,122 @@ func parseADRRelatedTable(s *store.Store, body, sectionName, colName, targetType
 		targetID := strings.TrimSpace(row[colName])
 		whyRequired := strings.TrimSpace(row["Why required"])
 		action := strings.ToLower(strings.TrimSpace(row["Action"]))
+		evidence := strings.TrimSpace(row["Evidence"])
 		if isNARow(targetID) {
 			continue
 		}
-		if targetID == "" {
+
+		// One pass per row, same as parseADRAffectedTopology: independent cells
+		// yield independent findings.
+		var entity *store.Entity
+		creating := false
+		rowResolved := true
+		switch {
+		case targetID == "":
+			rowResolved = false
 			issues = append(issues, Issue{
 				Severity: severity,
 				Message:  fmt.Sprintf("%s rows must include %s, or use N.A - <reason>", sectionName, colName),
 				Hint:     fmt.Sprintf("fill the %s column for each %s row", colName, sectionName),
 			})
-			continue
+		default:
+			resolved, err := s.GetEntity(targetID)
+			if err != nil {
+				rowResolved = false
+				bare := bareIDFromCell(s, targetID)
+				switch {
+				case bare != "":
+					issues = append(issues, freeFormIDCellIssue(sectionName, colName, "Why required", targetID, bare, severity))
+				case strings.Contains(action, "create"):
+					// A create action legitimately names a target that does not
+					// exist yet, so its Evidence may be N.A.
+					creating = true
+				default:
+					issues = append(issues, Issue{
+						Severity: severity,
+						Message:  fmt.Sprintf("%s references unknown %s: %s", sectionName, targetType, targetID),
+						Hint:     fmt.Sprintf("create %s first, or mark the Action as create-%s", targetID, targetType),
+					})
+				}
+				break
+			}
+			entity = resolved
+			if resolved.Type != targetType {
+				rowResolved = false
+				issues = append(issues, Issue{
+					Severity: severity,
+					Message:  fmt.Sprintf("%s type mismatch: %s is %s, not %s", sectionName, targetID, resolved.Type, targetType),
+					Hint:     fmt.Sprintf("move %s to the correct ADR section", targetID),
+				})
+			}
 		}
+
 		if whyRequired == "" || isNARow(whyRequired) {
+			rowResolved = false
 			issues = append(issues, Issue{
 				Severity: severity,
 				Message:  fmt.Sprintf("%s row for %s must explain why compliance/review is required", sectionName, targetID),
 				Hint:     "fill the Why required column with the compliance reason, or mark the entire row N.A - <reason>",
 			})
-			continue
 		}
-		entity, err := s.GetEntity(targetID)
-		if err != nil {
-			if strings.Contains(action, "create") {
-				issues = append(issues, validateADREvidence(s, sectionName, targetID, strings.TrimSpace(row["Evidence"]), severity, true)...)
-				continue
-			}
-			issues = append(issues, Issue{
-				Severity: severity,
-				Message:  fmt.Sprintf("%s references unknown %s: %s", sectionName, targetType, targetID),
-				Hint:     fmt.Sprintf("create %s first, or mark the Action as create-%s", targetID, targetType),
-			})
-			continue
+
+		// Deliberate dependency: only a resolved (or being-created) target lets
+		// Evidence be checked against it; otherwise just the cell-shape checks.
+		switch {
+		case entity != nil:
+			issues = append(issues, validateADREvidence(s, sectionName, targetID, evidence, severity, false)...)
+		case creating:
+			issues = append(issues, validateADREvidence(s, sectionName, targetID, evidence, severity, true)...)
+		default:
+			_, shapeIssues := validateADREvidenceShape(sectionName, targetID, evidence, severity, false)
+			issues = append(issues, shapeIssues...)
 		}
-		if entity.Type != targetType {
-			issues = append(issues, Issue{
-				Severity: severity,
-				Message:  fmt.Sprintf("%s type mismatch: %s is %s, not %s", sectionName, targetID, entity.Type, targetType),
-				Hint:     fmt.Sprintf("move %s to the correct ADR section", targetID),
-			})
-			continue
+
+		if rowResolved {
+			mentioned[targetID] = true
 		}
-		issues = append(issues, validateADREvidence(s, sectionName, targetID, strings.TrimSpace(row["Evidence"]), severity, false)...)
-		mentioned[targetID] = true
 	}
 	return mentioned, issues
 }
 
-func validateADREvidence(s *store.Store, sectionName, targetID, raw string, severity string, allowNA bool) []Issue {
+// validateADREvidenceShape runs the Evidence checks that need nothing but the
+// cell text — present, not N.A, parseable as a cite handle — and returns the
+// parsed handle when there is one. Split out so a row whose target does not
+// resolve still gets its Evidence reported in the same pass; only the
+// target-relative checks are genuinely blocked.
+func validateADREvidenceShape(sectionName, targetID, raw string, severity string, allowNA bool) ([]string, []Issue) {
 	if raw == "" {
-		return []Issue{{
+		return nil, []Issue{{
 			Severity: severity,
 			Message:  fmt.Sprintf("%s row for %s must include Evidence citation", sectionName, targetID),
-			Hint:     fmt.Sprintf("run c3x read %s --section <section> --cite and paste the matching handle, or use N.A - <reason> only when creating a new target", targetID),
+			Hint:     fmt.Sprintf("run %s and paste the matching handle, or use N.A - <reason> only when creating a new target", nodeCiteCommand(targetID)),
 		}}
 	}
 	if strings.HasPrefix(raw, "N.A -") {
 		if allowNA {
-			return nil
+			return nil, nil
 		}
-		return []Issue{{
+		return nil, []Issue{{
 			Severity: severity,
 			Message:  fmt.Sprintf("%s row for %s must cite current C3 evidence, not N.A", sectionName, targetID),
-			Hint:     fmt.Sprintf("run c3x read %s --section <section> --cite and paste the matching handle", targetID),
+			Hint:     fmt.Sprintf("run %s and paste the matching handle", nodeCiteCommand(targetID)),
 		}}
 	}
-
 	m := citationHandleRE.FindStringSubmatch(raw)
 	if m == nil {
-		return []Issue{{
+		return nil, []Issue{{
 			Severity: severity,
 			Message:  fmt.Sprintf("%s row for %s has invalid Evidence citation", sectionName, targetID),
-			Hint:     `expected <entity>#n<node>@v<version>:sha256:<nodeHash> "exact snippet" from c3x read --cite`,
+			Hint:     fmt.Sprintf(`expected <entity>#n<node>@v<version>:sha256:<nodeHash> "exact snippet" from %s`, nodeCiteCommand(targetID)),
 		}}
+	}
+	return m, nil
+}
+
+func validateADREvidence(s *store.Store, sectionName, targetID, raw string, severity string, allowNA bool) []Issue {
+	m, issues := validateADREvidenceShape(sectionName, targetID, raw, severity, allowNA)
+	if m == nil {
+		return issues
 	}
 
 	citedEntity := m[1]
@@ -351,47 +450,103 @@ func validateADREvidence(s *store.Store, sectionName, targetID, raw string, seve
 		return []Issue{{
 			Severity: severity,
 			Message:  fmt.Sprintf("Evidence for %s row %s cites version %d, current version is %d", sectionName, targetID, version, entity.Version),
-			Hint:     fmt.Sprintf("refresh the handle with c3x read %s --cite", targetID),
+			Hint:     fmt.Sprintf("refresh the handle with %s", nodeCiteCommand(targetID)),
 		}}
 	}
 
-	if evidenceNodeMatches(s, citedEntity, nodeID, hash, snippet) {
+	outcome, node := evidenceNodeMatches(s, citedEntity, nodeID, hash, snippet)
+	switch outcome {
+	case evidenceNodeOK:
 		return nil
-	}
-	if node, err := s.GetNode(nodeID); err == nil && node.EntityID != citedEntity {
+	case evidenceNodeSnippetMismatch:
 		return []Issue{{
 			Severity: severity,
-			Message:  fmt.Sprintf("Evidence for %s row %s cites node %d from %s", sectionName, targetID, nodeID, node.EntityID),
-			Hint:     fmt.Sprintf("refresh the handle with c3x read %s --cite", targetID),
+			Message:  fmt.Sprintf("Evidence for %s row %s has a snippet that does not match: the cited sha256 is current, but that node begins %q, not %q", sectionName, targetID, citeExcerpt(node.Content), citeExcerpt(snippet)),
+			Hint:     fmt.Sprintf("re-copy the snippet from %s, or drop it: the sha256 is the anchor and the snippet is optional", nodeCiteCommand(targetID)),
+		}}
+	}
+	if other, err := s.GetNode(nodeID); err == nil && other.EntityID != citedEntity {
+		return []Issue{{
+			Severity: severity,
+			Message:  fmt.Sprintf("Evidence for %s row %s cites node %d from %s", sectionName, targetID, nodeID, other.EntityID),
+			Hint:     fmt.Sprintf("refresh the handle with %s", nodeCiteCommand(targetID)),
 		}}
 	}
 	return []Issue{{
 		Severity: severity,
 		Message:  fmt.Sprintf("Evidence for %s row %s has a stale cite (no node of %s seals to that hash)", sectionName, targetID, citedEntity),
-		Hint:     fmt.Sprintf("refresh the handle with c3x read %s --cite", targetID),
+		Hint:     fmt.Sprintf("refresh the handle with %s", nodeCiteCommand(targetID)),
 	}}
 }
 
-func evidenceNodeMatches(s *store.Store, entityID string, nodeID int64, hash, snippet string) bool {
+// evidenceNodeOutcome names WHICH half of a cite failed. The two causes are
+// independent and want opposite remedies — a hash no node seals to is stale and
+// wants a refresh, while a current hash with a non-matching snippet wants the
+// snippet re-copied — so collapsing them into one bool made the reported cause
+// affirmatively false half the time.
+type evidenceNodeOutcome int
+
+const (
+	evidenceNodeOK evidenceNodeOutcome = iota
+	evidenceNodeHashUnknown
+	evidenceNodeSnippetMismatch
+)
+
+// evidenceNodeMatches resolves a cite against an entity's nodes, returning the
+// hash-matching node when there is one so the caller can show its actual text.
+func evidenceNodeMatches(s *store.Store, entityID string, nodeID int64, hash, snippet string) (evidenceNodeOutcome, *store.Node) {
 	// The sha256 is the anchor; a snippet, when present, must also be contained.
 	// Matching by hash across all of the entity's nodes makes a cite resilient to
 	// node-id renumbering (same content, new integer id).
+	var hashOnly *store.Node
 	matches := func(node *store.Node) bool {
-		return node.Hash == hash && (snippet == "" || strings.Contains(node.Content, snippet))
-	}
-	if node, err := s.GetNode(nodeID); err == nil && node.EntityID == entityID && matches(node) {
-		return true
-	}
-	nodes, err := s.NodesForEntity(entityID)
-	if err != nil {
-		return false
-	}
-	for _, node := range nodes {
-		if matches(node) {
+		if node.Hash != hash {
+			return false
+		}
+		if snippet == "" || strings.Contains(node.Content, snippet) {
 			return true
 		}
+		if hashOnly == nil {
+			hashOnly = node
+		}
+		return false
 	}
-	return false
+	if node, err := s.GetNode(nodeID); err == nil && node.EntityID == entityID && matches(node) {
+		return evidenceNodeOK, node
+	}
+	if nodes, err := s.NodesForEntity(entityID); err == nil {
+		for _, node := range nodes {
+			if matches(node) {
+				return evidenceNodeOK, node
+			}
+		}
+	}
+	if hashOnly != nil {
+		return evidenceNodeSnippetMismatch, hashOnly
+	}
+	return evidenceNodeHashUnknown, nil
+}
+
+// nodeCiteCommand names the invocation that actually emits a per-NODE handle.
+// Bare `c3x read <id> --cite` emits the ENTITY-ROOT handle, which the cite
+// grammar rejects — hints that named it sent readers in a circle, re-fetching a
+// value this validator had just refused.
+func nodeCiteCommand(id string) string {
+	return fmt.Sprintf("c3x read %s --section <name> --cite", id)
+}
+
+// citeExcerpt reduces a snippet or node body to one short single-line excerpt,
+// so a cited-vs-actual comparison fits on an error line instead of dumping the
+// whole node.
+func citeExcerpt(text string) string {
+	excerpt := strings.TrimSpace(text)
+	if i := strings.IndexByte(excerpt, '\n'); i >= 0 {
+		excerpt = strings.TrimSpace(excerpt[:i])
+	}
+	if len(excerpt) > 80 {
+		excerpt = excerpt[:80] + "..."
+	}
+	return excerpt
 }
 
 func extractADRTable(body, sectionName, severity string, schemaCommand string) (*markdown.Table, bool, []Issue) {

--- a/cli/cmd/adr_linkage.go
+++ b/cli/cmd/adr_linkage.go
@@ -201,14 +201,11 @@ func parseADRAffectedTopology(s *store.Store, body string, severity string, sche
 			continue
 		}
 
-		// One pass per row: the cells fail independently, so collect every
-		// finding instead of bailing at the first. Bailing made a blank Why hide
-		// the row's Evidence defect, costing a submission round-trip per class.
-		var entity *store.Entity
-		rowResolved := true
+		targetResolved := false
+		rowUsableAsTarget := true
 		switch {
 		case entityID == "" || targetType == "":
-			rowResolved = false
+			rowUsableAsTarget = false
 			issues = append(issues, Issue{
 				Severity: severity,
 				Message:  "Affected Topology rows must include both Entity and Type, or use N.A - <reason>",
@@ -217,9 +214,9 @@ func parseADRAffectedTopology(s *store.Store, body string, severity string, sche
 		default:
 			resolved, err := s.GetEntity(entityID)
 			if err != nil {
-				rowResolved = false
-				if bare := bareIDFromCell(s, entityID); bare != "" {
-					issues = append(issues, freeFormIDCellIssue("Affected Topology", "Entity", "Why affected", entityID, bare, severity))
+				rowUsableAsTarget = false
+				if bareID := knownEntityIDPrefix(s, entityID); bareID != "" {
+					issues = append(issues, freeFormIDCellIssue("Affected Topology", "Entity", "Why affected", entityID, bareID, severity))
 					break
 				}
 				issues = append(issues, Issue{
@@ -229,9 +226,9 @@ func parseADRAffectedTopology(s *store.Store, body string, severity string, sche
 				})
 				break
 			}
-			entity = resolved
+			targetResolved = true
 			if resolved.Type != targetType {
-				rowResolved = false
+				rowUsableAsTarget = false
 				issues = append(issues, Issue{
 					Severity: severity,
 					Message:  fmt.Sprintf("Affected Topology type mismatch: %s is %s, not %s", entityID, resolved.Type, targetType),
@@ -241,7 +238,7 @@ func parseADRAffectedTopology(s *store.Store, body string, severity string, sche
 		}
 
 		if whyAffected == "" || isNARow(whyAffected) {
-			rowResolved = false
+			rowUsableAsTarget = false
 			issues = append(issues, Issue{
 				Severity: severity,
 				Message:  fmt.Sprintf("Affected Topology row for %s must explain why it is affected", entityID),
@@ -249,42 +246,32 @@ func parseADRAffectedTopology(s *store.Store, body string, severity string, sche
 			})
 		}
 
-		// Deliberate dependency, not an early bail: the version/hash/snippet
-		// checks compare Evidence AGAINST the row target, so an Entity cell that
-		// did not resolve leaves only the cell-shape checks runnable.
-		if entity != nil {
-			issues = append(issues, validateADREvidence(s, "Affected Topology", entityID, evidence, severity, false)...)
+		if targetResolved {
+			issues = append(issues, validateADREvidence(s, "Affected Topology", entityID, evidence, severity, evidenceNARejected)...)
 		} else {
-			_, shapeIssues := validateADREvidenceShape("Affected Topology", entityID, evidence, severity, false)
-			issues = append(issues, shapeIssues...)
+			_, cellShapeIssues := validateADREvidenceCellShape("Affected Topology", entityID, evidence, severity, evidenceNARejected)
+			issues = append(issues, cellShapeIssues...)
 		}
 
-		if rowResolved {
+		if rowUsableAsTarget {
 			targets = append(targets, adrAffectedTarget{ID: entityID, Type: targetType})
 		}
 	}
 	return targets, issues
 }
 
-// bareIDFromCell reports the first whitespace-separated token of an id cell when
-// that token resolves to a known entity — i.e. the author wrote a DECORATED cell
-// ("c3-3 shared (prompt.ts)") rather than naming something that does not exist.
-// Empty when the cell is a single token or nothing in it resolves, so the caller
-// keeps the plain unknown-target finding.
-func bareIDFromCell(s *store.Store, cell string) string {
-	fields := strings.Fields(cell)
-	if len(fields) < 2 {
+func knownEntityIDPrefix(s *store.Store, cell string) string {
+	tokens := strings.Fields(cell)
+	cellIsDecorated := len(tokens) > 1
+	if !cellIsDecorated {
 		return ""
 	}
-	if _, err := s.GetEntity(fields[0]); err != nil {
+	if _, err := s.GetEntity(tokens[0]); err != nil {
 		return ""
 	}
-	return fields[0]
+	return tokens[0]
 }
 
-// freeFormIDCellIssue names the id it found instead of interpolating the whole
-// cell as one. The old "unknown entity: c3-3 shared (prompt.ts)" sent authors
-// hunting for a missing entity when the real fix was to trim the cell.
 func freeFormIDCellIssue(sectionName, colName, proseCol, cell, bareID, severity string) Issue {
 	return Issue{
 		Severity: severity,
@@ -311,14 +298,12 @@ func parseADRRelatedTable(s *store.Store, body, sectionName, colName, targetType
 			continue
 		}
 
-		// One pass per row, same as parseADRAffectedTopology: independent cells
-		// yield independent findings.
-		var entity *store.Entity
-		creating := false
-		rowResolved := true
+		targetResolved := false
+		targetWillBeCreated := false
+		rowUsableAsTarget := true
 		switch {
 		case targetID == "":
-			rowResolved = false
+			rowUsableAsTarget = false
 			issues = append(issues, Issue{
 				Severity: severity,
 				Message:  fmt.Sprintf("%s rows must include %s, or use N.A - <reason>", sectionName, colName),
@@ -327,15 +312,13 @@ func parseADRRelatedTable(s *store.Store, body, sectionName, colName, targetType
 		default:
 			resolved, err := s.GetEntity(targetID)
 			if err != nil {
-				rowResolved = false
-				bare := bareIDFromCell(s, targetID)
+				rowUsableAsTarget = false
+				bareID := knownEntityIDPrefix(s, targetID)
 				switch {
-				case bare != "":
-					issues = append(issues, freeFormIDCellIssue(sectionName, colName, "Why required", targetID, bare, severity))
+				case bareID != "":
+					issues = append(issues, freeFormIDCellIssue(sectionName, colName, "Why required", targetID, bareID, severity))
 				case strings.Contains(action, "create"):
-					// A create action legitimately names a target that does not
-					// exist yet, so its Evidence may be N.A.
-					creating = true
+					targetWillBeCreated = true
 				default:
 					issues = append(issues, Issue{
 						Severity: severity,
@@ -345,9 +328,9 @@ func parseADRRelatedTable(s *store.Store, body, sectionName, colName, targetType
 				}
 				break
 			}
-			entity = resolved
+			targetResolved = true
 			if resolved.Type != targetType {
-				rowResolved = false
+				rowUsableAsTarget = false
 				issues = append(issues, Issue{
 					Severity: severity,
 					Message:  fmt.Sprintf("%s type mismatch: %s is %s, not %s", sectionName, targetID, resolved.Type, targetType),
@@ -357,7 +340,7 @@ func parseADRRelatedTable(s *store.Store, body, sectionName, colName, targetType
 		}
 
 		if whyRequired == "" || isNARow(whyRequired) {
-			rowResolved = false
+			rowUsableAsTarget = false
 			issues = append(issues, Issue{
 				Severity: severity,
 				Message:  fmt.Sprintf("%s row for %s must explain why compliance/review is required", sectionName, targetID),
@@ -365,31 +348,29 @@ func parseADRRelatedTable(s *store.Store, body, sectionName, colName, targetType
 			})
 		}
 
-		// Deliberate dependency: only a resolved (or being-created) target lets
-		// Evidence be checked against it; otherwise just the cell-shape checks.
 		switch {
-		case entity != nil:
-			issues = append(issues, validateADREvidence(s, sectionName, targetID, evidence, severity, false)...)
-		case creating:
-			issues = append(issues, validateADREvidence(s, sectionName, targetID, evidence, severity, true)...)
+		case targetResolved:
+			issues = append(issues, validateADREvidence(s, sectionName, targetID, evidence, severity, evidenceNARejected)...)
+		case targetWillBeCreated:
+			issues = append(issues, validateADREvidence(s, sectionName, targetID, evidence, severity, evidenceNAAllowed)...)
 		default:
-			_, shapeIssues := validateADREvidenceShape(sectionName, targetID, evidence, severity, false)
-			issues = append(issues, shapeIssues...)
+			_, cellShapeIssues := validateADREvidenceCellShape(sectionName, targetID, evidence, severity, evidenceNARejected)
+			issues = append(issues, cellShapeIssues...)
 		}
 
-		if rowResolved {
+		if rowUsableAsTarget {
 			mentioned[targetID] = true
 		}
 	}
 	return mentioned, issues
 }
 
-// validateADREvidenceShape runs the Evidence checks that need nothing but the
-// cell text — present, not N.A, parseable as a cite handle — and returns the
-// parsed handle when there is one. Split out so a row whose target does not
-// resolve still gets its Evidence reported in the same pass; only the
-// target-relative checks are genuinely blocked.
-func validateADREvidenceShape(sectionName, targetID, raw string, severity string, allowNA bool) ([]string, []Issue) {
+const (
+	evidenceNARejected = false
+	evidenceNAAllowed  = true
+)
+
+func validateADREvidenceCellShape(sectionName, targetID, raw string, severity string, allowNA bool) (handleMatch []string, issues []Issue) {
 	if raw == "" {
 		return nil, []Issue{{
 			Severity: severity,
@@ -419,7 +400,7 @@ func validateADREvidenceShape(sectionName, targetID, raw string, severity string
 }
 
 func validateADREvidence(s *store.Store, sectionName, targetID, raw string, severity string, allowNA bool) []Issue {
-	m, issues := validateADREvidenceShape(sectionName, targetID, raw, severity, allowNA)
+	m, issues := validateADREvidenceCellShape(sectionName, targetID, raw, severity, allowNA)
 	if m == nil {
 		return issues
 	}
@@ -454,7 +435,7 @@ func validateADREvidence(s *store.Store, sectionName, targetID, raw string, seve
 		}}
 	}
 
-	outcome, node := evidenceNodeMatches(s, citedEntity, nodeID, hash, snippet)
+	outcome, node := resolveEvidenceNode(s, citedEntity, nodeID, hash, snippet)
 	switch outcome {
 	case evidenceNodeOK:
 		return nil
@@ -479,11 +460,6 @@ func validateADREvidence(s *store.Store, sectionName, targetID, raw string, seve
 	}}
 }
 
-// evidenceNodeOutcome names WHICH half of a cite failed. The two causes are
-// independent and want opposite remedies — a hash no node seals to is stale and
-// wants a refresh, while a current hash with a non-matching snippet wants the
-// snippet re-copied — so collapsing them into one bool made the reported cause
-// affirmatively false half the time.
 type evidenceNodeOutcome int
 
 const (
@@ -492,13 +468,11 @@ const (
 	evidenceNodeSnippetMismatch
 )
 
-// evidenceNodeMatches resolves a cite against an entity's nodes, returning the
-// hash-matching node when there is one so the caller can show its actual text.
-func evidenceNodeMatches(s *store.Store, entityID string, nodeID int64, hash, snippet string) (evidenceNodeOutcome, *store.Node) {
+func resolveEvidenceNode(s *store.Store, entityID string, nodeID int64, hash, snippet string) (evidenceNodeOutcome, *store.Node) {
 	// The sha256 is the anchor; a snippet, when present, must also be contained.
 	// Matching by hash across all of the entity's nodes makes a cite resilient to
 	// node-id renumbering (same content, new integer id).
-	var hashOnly *store.Node
+	var hashMatchWithWrongSnippet *store.Node
 	matches := func(node *store.Node) bool {
 		if node.Hash != hash {
 			return false
@@ -506,8 +480,8 @@ func evidenceNodeMatches(s *store.Store, entityID string, nodeID int64, hash, sn
 		if snippet == "" || strings.Contains(node.Content, snippet) {
 			return true
 		}
-		if hashOnly == nil {
-			hashOnly = node
+		if hashMatchWithWrongSnippet == nil {
+			hashMatchWithWrongSnippet = node
 		}
 		return false
 	}
@@ -521,30 +495,26 @@ func evidenceNodeMatches(s *store.Store, entityID string, nodeID int64, hash, sn
 			}
 		}
 	}
-	if hashOnly != nil {
-		return evidenceNodeSnippetMismatch, hashOnly
+	if hashMatchWithWrongSnippet != nil {
+		return evidenceNodeSnippetMismatch, hashMatchWithWrongSnippet
 	}
 	return evidenceNodeHashUnknown, nil
 }
 
-// nodeCiteCommand names the invocation that actually emits a per-NODE handle.
-// Bare `c3x read <id> --cite` emits the ENTITY-ROOT handle, which the cite
-// grammar rejects — hints that named it sent readers in a circle, re-fetching a
-// value this validator had just refused.
+// Bare `c3x read <id> --cite` emits the entity-root handle, which the cite grammar rejects.
 func nodeCiteCommand(id string) string {
 	return fmt.Sprintf("c3x read %s --section <name> --cite", id)
 }
 
-// citeExcerpt reduces a snippet or node body to one short single-line excerpt,
-// so a cited-vs-actual comparison fits on an error line instead of dumping the
-// whole node.
+const citeExcerptMaxLen = 80
+
 func citeExcerpt(text string) string {
 	excerpt := strings.TrimSpace(text)
 	if i := strings.IndexByte(excerpt, '\n'); i >= 0 {
 		excerpt = strings.TrimSpace(excerpt[:i])
 	}
-	if len(excerpt) > 80 {
-		excerpt = excerpt[:80] + "..."
+	if len(excerpt) > citeExcerptMaxLen {
+		excerpt = excerpt[:citeExcerptMaxLen] + "..."
 	}
 	return excerpt
 }

--- a/cli/cmd/adr_linkage_diagnostics_test.go
+++ b/cli/cmd/adr_linkage_diagnostics_test.go
@@ -7,13 +7,6 @@ import (
 	"github.com/lagz0ne/c3-design/cli/internal/store"
 )
 
-// Diagnostics quality for change-doc linkage: a finding must name the cause it
-// actually observed (issues #111, #112, #114), point at the invocation that
-// produces the value it wants (#114), surface every independent finding in one
-// pass (#116), and stay typed on free-form cells (#94).
-
-// swapCiteSnippet replaces the trailing "snippet" of a cite handle, leaving the
-// entity/node/version/sha256 anchor current.
 func swapCiteSnippet(t *testing.T, handle, snippet string) string {
 	t.Helper()
 	i := strings.Index(handle, ` "`)
@@ -23,8 +16,6 @@ func swapCiteSnippet(t *testing.T, handle, snippet string) string {
 	return handle[:i] + ` "` + snippet + `"`
 }
 
-// adrTopoBodyWithEvidence builds an Affected Topology table with a per-row
-// Evidence cell, so a row can carry several independent defects at once.
 func adrTopoBodyWithEvidence(rows [][4]string) string {
 	b := "# Sample ADR\n\n## Affected Topology\n\n" +
 		"| Entity | Type | Why affected | Evidence | Governance review |\n" +
@@ -35,7 +26,6 @@ func adrTopoBodyWithEvidence(rows [][4]string) string {
 	return b
 }
 
-// adrRelatedBody builds a Compliance Refs table with per-row cells.
 func adrRelatedBody(rows [][4]string) string {
 	b := "# Sample ADR\n\n## Compliance Refs\n\n" +
 		"| Ref | Why required | Evidence | Action |\n" +
@@ -46,8 +36,7 @@ func adrRelatedBody(rows [][4]string) string {
 	return b
 }
 
-// hintForIssue returns the Hint of the first issue whose Message contains needle.
-func hintForIssue(t *testing.T, issues []Issue, needle string) string {
+func hintForIssueMentioning(t *testing.T, issues []Issue, needle string) string {
 	t.Helper()
 	for _, issue := range issues {
 		if strings.Contains(issue.Message, needle) {
@@ -58,16 +47,11 @@ func hintForIssue(t *testing.T, issues []Issue, needle string) string {
 	return ""
 }
 
-// ---------------------------------------------------------------------------
-// A — the two cite failure causes get two different messages
-// ---------------------------------------------------------------------------
-
 func TestADREvidence_SnippetMismatchIsNotReportedAsStale(t *testing.T) {
 	s := createRichDBFixture(t)
-	// Anchor (sha256) is CURRENT; only the snippet was mis-copied.
-	handle := swapCiteSnippet(t, testCitationForEntity(t, s, "c3-1"), "a snippet nobody wrote")
+	currentAnchorWrongSnippet := swapCiteSnippet(t, testCitationForEntity(t, s, "c3-1"), "a snippet nobody wrote")
 
-	issues := validateADREvidence(s, "Affected Topology", "c3-1", handle, "warning", false)
+	issues := validateADREvidence(s, "Affected Topology", "c3-1", currentAnchorWrongSnippet, "warning", false)
 	if len(issues) != 1 {
 		t.Fatalf("expected exactly one issue, got %+v", issues)
 	}
@@ -77,7 +61,6 @@ func TestADREvidence_SnippetMismatchIsNotReportedAsStale(t *testing.T) {
 	if !strings.Contains(issues[0].Message, "snippet") {
 		t.Fatalf("expected the message to name the snippet, got %q", issues[0].Message)
 	}
-	// The cited snippet and the node's actual leading text must both be visible.
 	if !strings.Contains(issues[0].Message, "a snippet nobody wrote") {
 		t.Fatalf("expected the cited snippet to be echoed, got %q", issues[0].Message)
 	}
@@ -107,9 +90,9 @@ func TestADREvidence_UnknownHashKeepsStaleMessage(t *testing.T) {
 
 func TestCitationColumn_SnippetMismatchIsNotReportedAsStale(t *testing.T) {
 	s := createRichDBFixture(t)
-	handle := swapCiteSnippet(t, testCitationForEntity(t, s, "c3-1"), "a snippet nobody wrote")
+	currentAnchorWrongSnippet := swapCiteSnippet(t, testCitationForEntity(t, s, "c3-1"), "a snippet nobody wrote")
 
-	issues := validateCitationColumnValue(handle, mustEntity(t, s, "c3-1"), citeOpts(s))
+	issues := validateCitationColumnValue(currentAnchorWrongSnippet, mustEntity(t, s, "c3-1"), citeOpts(s))
 	if len(issues) != 1 {
 		t.Fatalf("expected exactly one issue, got %+v", issues)
 	}
@@ -125,17 +108,16 @@ func TestCitationColumn_SnippetMismatchIsNotReportedAsStale(t *testing.T) {
 	}
 }
 
-// Truncation: a cite against a long node must not dump the node into the line.
-func TestCitationColumn_SnippetMismatchTruncates(t *testing.T) {
+func TestCitationColumn_SnippetMismatchExcerptsInsteadOfDumpingTheNode(t *testing.T) {
 	s := createRichDBFixture(t)
-	long := strings.Repeat("x", 400)
-	handle := swapCiteSnippet(t, testCitationForEntity(t, s, "c3-1"), long)
+	longSnippet := strings.Repeat("x", 400)
+	handle := swapCiteSnippet(t, testCitationForEntity(t, s, "c3-1"), longSnippet)
 
 	issues := validateCitationColumnValue(handle, mustEntity(t, s, "c3-1"), citeOpts(s))
 	if len(issues) != 1 {
 		t.Fatalf("expected exactly one issue, got %+v", issues)
 	}
-	if strings.Contains(issues[0].Message, long) {
+	if strings.Contains(issues[0].Message, longSnippet) {
 		t.Fatalf("message must truncate the cited snippet, got %q", issues[0].Message)
 	}
 	if len(issues[0].Message) > 400 {
@@ -143,17 +125,12 @@ func TestCitationColumn_SnippetMismatchTruncates(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// B — the invalid-handle hint must name the invocation that emits node handles
-// ---------------------------------------------------------------------------
-
-func TestADREvidence_InvalidHandleHintNamesSection(t *testing.T) {
+func TestADREvidence_EntityRootHandleHintNamesSection(t *testing.T) {
 	s := createRichDBFixture(t)
 	entity := mustEntity(t, s, "c3-1")
-	// The ENTITY-ROOT form bare `read --cite` emits — rejected by the grammar.
-	root := entity.ID + "@v1:sha256:" + strings.Repeat("a", 64)
+	entityRootHandle := entity.ID + "@v1:sha256:" + strings.Repeat("a", 64)
 
-	issues := validateADREvidence(s, "Affected Topology", "c3-1", root, "warning", false)
+	issues := validateADREvidence(s, "Affected Topology", "c3-1", entityRootHandle, "warning", false)
 	if len(issues) != 1 {
 		t.Fatalf("expected the invalid-citation issue, got %+v", issues)
 	}
@@ -162,11 +139,11 @@ func TestADREvidence_InvalidHandleHintNamesSection(t *testing.T) {
 	}
 }
 
-func TestCitationColumn_InvalidHandleHintNamesSection(t *testing.T) {
+func TestCitationColumn_EntityRootHandleHintNamesSection(t *testing.T) {
 	s := createRichDBFixture(t)
-	root := "c3-1@v1:sha256:" + strings.Repeat("a", 64)
+	entityRootHandle := "c3-1@v1:sha256:" + strings.Repeat("a", 64)
 
-	issues := validateCitationColumnValue(root, mustEntity(t, s, "c3-1"), citeOpts(s))
+	issues := validateCitationColumnValue(entityRootHandle, mustEntity(t, s, "c3-1"), citeOpts(s))
 	if len(issues) != 1 {
 		t.Fatalf("expected the invalid-citation issue, got %+v", issues)
 	}
@@ -174,10 +151,6 @@ func TestCitationColumn_InvalidHandleHintNamesSection(t *testing.T) {
 		t.Fatalf("hint must name --section <name>, got %q", issues[0].Hint)
 	}
 }
-
-// ---------------------------------------------------------------------------
-// C — every independent finding in a row surfaces in one pass
-// ---------------------------------------------------------------------------
 
 func TestAffectedTopology_ReportsWhyAndEvidenceTogether(t *testing.T) {
 	s := createRichDBFixture(t)
@@ -207,9 +180,7 @@ func TestAffectedTopology_ReportsTypeMismatchAndEvidenceTogether(t *testing.T) {
 	}
 }
 
-// An unresolvable Entity blocks only the entity-relative Evidence checks; the
-// cell-shape ones still run.
-func TestAffectedTopology_UnknownEntityStillReportsEvidenceShape(t *testing.T) {
+func TestAffectedTopology_UnknownEntityStillReportsEvidenceCellShape(t *testing.T) {
 	s := createRichDBFixture(t)
 	body := adrTopoBodyWithEvidence([][4]string{{"c3-999", "component", "", "not a handle at all"}})
 
@@ -253,8 +224,7 @@ func TestRelatedTable_ReportsTypeMismatchAndEvidenceTogether(t *testing.T) {
 	}
 }
 
-// Rows stay independent: a broken row does not consume its neighbour's findings.
-func TestAffectedTopology_RowsRemainIndependent(t *testing.T) {
+func TestAffectedTopology_BrokenRowDoesNotSuppressTheNextRowsFindings(t *testing.T) {
 	s := createRichDBFixture(t)
 	body := adrTopoBodyWithEvidence([][4]string{
 		{"c3-999", "component", "", "not a handle at all"},
@@ -273,13 +243,7 @@ func TestAffectedTopology_RowsRemainIndependent(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// D — free-form cells stay typed findings (issue #94), and name the bare id
-// ---------------------------------------------------------------------------
-
-// A free-form Entity / Ref cell once nil-derefed. Pin the no-panic behaviour so
-// a regression reports as a failure, not a crashed run.
-func TestFreeFormCells_DoNotPanic(t *testing.T) {
+func TestFreeFormCells_ReportTypedFindingsInsteadOfPanicking(t *testing.T) {
 	s := createRichDBFixture(t)
 	freeForm := "c3-3 shared (kanna-system-prompt.ts)"
 
@@ -309,8 +273,8 @@ func TestFreeFormCells_DoNotPanic(t *testing.T) {
 
 func TestAffectedTopology_FreeFormEntityCellNamesTheBareID(t *testing.T) {
 	s := createRichDBFixture(t)
-	// First token IS a known entity — the cell is decorated, not unknown.
-	body := adrTopoBodyWithEvidence([][4]string{{"c3-1 shared (kanna-system-prompt.ts)", "container", "boundary moves", "N.A - none"}})
+	decoratedKnownEntityCell := "c3-1 shared (kanna-system-prompt.ts)"
+	body := adrTopoBodyWithEvidence([][4]string{{decoratedKnownEntityCell, "container", "boundary moves", "N.A - none"}})
 
 	_, issues := parseADRAffectedTopology(s, body, "warning", adrSchemaHint())
 	if hasIssue(issues, "unknown entity") {
@@ -319,14 +283,15 @@ func TestAffectedTopology_FreeFormEntityCellNamesTheBareID(t *testing.T) {
 	if !hasIssue(issues, "only the bare id") {
 		t.Fatalf("expected a bare-id finding, got %#v", issues)
 	}
-	if hint := hintForIssue(t, issues, "only the bare id"); !strings.Contains(hint, "use just c3-1") {
+	if hint := hintForIssueMentioning(t, issues, "only the bare id"); !strings.Contains(hint, "use just c3-1") {
 		t.Fatalf("expected the hint to name the id that was found, got %q", hint)
 	}
 }
 
 func TestAffectedTopology_UnrecognisedFreeFormStaysUnknownEntity(t *testing.T) {
 	s := createRichDBFixture(t)
-	body := adrTopoBodyWithEvidence([][4]string{{"c3-3 shared (kanna-system-prompt.ts)", "component", "shared prompt moves", "N.A - none"}})
+	decoratedUnknownEntityCell := "c3-3 shared (kanna-system-prompt.ts)"
+	body := adrTopoBodyWithEvidence([][4]string{{decoratedUnknownEntityCell, "component", "shared prompt moves", "N.A - none"}})
 
 	_, issues := parseADRAffectedTopology(s, body, "warning", adrSchemaHint())
 	if !hasIssue(issues, "unknown entity") {
@@ -336,7 +301,8 @@ func TestAffectedTopology_UnrecognisedFreeFormStaysUnknownEntity(t *testing.T) {
 
 func TestRelatedTable_FreeFormRefCellNamesTheBareID(t *testing.T) {
 	s := createRichDBFixture(t)
-	body := adrRelatedBody([][4]string{{"ref-jwt (see kanna-system-prompt.ts)", "token policy applies", "N.A - none", "comply"}})
+	decoratedKnownRefCell := "ref-jwt (see kanna-system-prompt.ts)"
+	body := adrRelatedBody([][4]string{{decoratedKnownRefCell, "token policy applies", "N.A - none", "comply"}})
 
 	_, issues := parseADRRelatedTable(s, body, "Compliance Refs", "Ref", "ref", "warning", adrSchemaHint())
 	if hasIssue(issues, "unknown ref") {
@@ -345,14 +311,12 @@ func TestRelatedTable_FreeFormRefCellNamesTheBareID(t *testing.T) {
 	if !hasIssue(issues, "only the bare id") {
 		t.Fatalf("expected a bare-id finding, got %#v", issues)
 	}
-	if hint := hintForIssue(t, issues, "only the bare id"); !strings.Contains(hint, "use just ref-jwt") {
+	if hint := hintForIssueMentioning(t, issues, "only the bare id"); !strings.Contains(hint, "use just ref-jwt") {
 		t.Fatalf("expected the hint to name the id that was found, got %q", hint)
 	}
 }
 
-// evidenceNodeMatches must distinguish the two failure causes; the old bare bool
-// is what let the callers assert the wrong one.
-func TestEvidenceNodeMatches_SeparatesHashFromSnippet(t *testing.T) {
+func TestResolveEvidenceNode_SeparatesStaleHashFromSnippetMismatch(t *testing.T) {
 	s := createRichDBFixture(t)
 	handle := testCitationForEntity(t, s, "c3-1")
 	nodes, err := s.NodesForEntity("c3-1")
@@ -370,17 +334,17 @@ func TestEvidenceNodeMatches_SeparatesHashFromSnippet(t *testing.T) {
 		t.Fatalf("could not locate the cited node for %s", handle)
 	}
 
-	if outcome, _ := evidenceNodeMatches(s, "c3-1", target.ID, target.Hash, ""); outcome != evidenceNodeOK {
+	if outcome, _ := resolveEvidenceNode(s, "c3-1", target.ID, target.Hash, ""); outcome != evidenceNodeOK {
 		t.Fatalf("a current hash must match, got %v", outcome)
 	}
-	outcome, node := evidenceNodeMatches(s, "c3-1", target.ID, target.Hash, "a snippet nobody wrote")
+	outcome, node := resolveEvidenceNode(s, "c3-1", target.ID, target.Hash, "a snippet nobody wrote")
 	if outcome != evidenceNodeSnippetMismatch {
 		t.Fatalf("a current hash with a bad snippet must report a snippet mismatch, got %v", outcome)
 	}
 	if node == nil || node.Hash != target.Hash {
 		t.Fatalf("expected the hash-matching node back so the message can show its text, got %+v", node)
 	}
-	if outcome, _ := evidenceNodeMatches(s, "c3-1", target.ID, strings.Repeat("0", 64), ""); outcome != evidenceNodeHashUnknown {
+	if outcome, _ := resolveEvidenceNode(s, "c3-1", target.ID, strings.Repeat("0", 64), ""); outcome != evidenceNodeHashUnknown {
 		t.Fatalf("a hash no node seals to must report hash-unknown, got %v", outcome)
 	}
 }

--- a/cli/cmd/adr_linkage_diagnostics_test.go
+++ b/cli/cmd/adr_linkage_diagnostics_test.go
@@ -1,0 +1,386 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lagz0ne/c3-design/cli/internal/store"
+)
+
+// Diagnostics quality for change-doc linkage: a finding must name the cause it
+// actually observed (issues #111, #112, #114), point at the invocation that
+// produces the value it wants (#114), surface every independent finding in one
+// pass (#116), and stay typed on free-form cells (#94).
+
+// swapCiteSnippet replaces the trailing "snippet" of a cite handle, leaving the
+// entity/node/version/sha256 anchor current.
+func swapCiteSnippet(t *testing.T, handle, snippet string) string {
+	t.Helper()
+	i := strings.Index(handle, ` "`)
+	if i < 0 {
+		t.Fatalf("handle has no snippet to swap: %s", handle)
+	}
+	return handle[:i] + ` "` + snippet + `"`
+}
+
+// adrTopoBodyWithEvidence builds an Affected Topology table with a per-row
+// Evidence cell, so a row can carry several independent defects at once.
+func adrTopoBodyWithEvidence(rows [][4]string) string {
+	b := "# Sample ADR\n\n## Affected Topology\n\n" +
+		"| Entity | Type | Why affected | Evidence | Governance review |\n" +
+		"|---|---|---|---|---|\n"
+	for _, r := range rows {
+		b += "| " + r[0] + " | " + r[1] + " | " + r[2] + " | " + r[3] + " | N.A - test |\n"
+	}
+	return b
+}
+
+// adrRelatedBody builds a Compliance Refs table with per-row cells.
+func adrRelatedBody(rows [][4]string) string {
+	b := "# Sample ADR\n\n## Compliance Refs\n\n" +
+		"| Ref | Why required | Evidence | Action |\n" +
+		"|---|---|---|---|\n"
+	for _, r := range rows {
+		b += "| " + r[0] + " | " + r[1] + " | " + r[2] + " | " + r[3] + " |\n"
+	}
+	return b
+}
+
+// hintForIssue returns the Hint of the first issue whose Message contains needle.
+func hintForIssue(t *testing.T, issues []Issue, needle string) string {
+	t.Helper()
+	for _, issue := range issues {
+		if strings.Contains(issue.Message, needle) {
+			return issue.Hint
+		}
+	}
+	t.Fatalf("no issue mentioning %q, got %#v", needle, issues)
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// A — the two cite failure causes get two different messages
+// ---------------------------------------------------------------------------
+
+func TestADREvidence_SnippetMismatchIsNotReportedAsStale(t *testing.T) {
+	s := createRichDBFixture(t)
+	// Anchor (sha256) is CURRENT; only the snippet was mis-copied.
+	handle := swapCiteSnippet(t, testCitationForEntity(t, s, "c3-1"), "a snippet nobody wrote")
+
+	issues := validateADREvidence(s, "Affected Topology", "c3-1", handle, "warning", false)
+	if len(issues) != 1 {
+		t.Fatalf("expected exactly one issue, got %+v", issues)
+	}
+	if strings.Contains(issues[0].Message, "stale") {
+		t.Fatalf("a fresh hash with a bad snippet must not be reported as stale: %q", issues[0].Message)
+	}
+	if !strings.Contains(issues[0].Message, "snippet") {
+		t.Fatalf("expected the message to name the snippet, got %q", issues[0].Message)
+	}
+	// The cited snippet and the node's actual leading text must both be visible.
+	if !strings.Contains(issues[0].Message, "a snippet nobody wrote") {
+		t.Fatalf("expected the cited snippet to be echoed, got %q", issues[0].Message)
+	}
+	if !strings.Contains(issues[0].Message, "Serve API requests") {
+		t.Fatalf("expected the node's actual leading text, got %q", issues[0].Message)
+	}
+	if strings.Contains(issues[0].Hint, "refresh the handle") {
+		t.Fatalf("re-fetching returns the same handle; hint must not say refresh: %q", issues[0].Hint)
+	}
+	if !strings.Contains(issues[0].Hint, "snippet") {
+		t.Fatalf("expected a re-copy/drop-the-snippet hint, got %q", issues[0].Hint)
+	}
+}
+
+func TestADREvidence_UnknownHashKeepsStaleMessage(t *testing.T) {
+	s := createRichDBFixture(t)
+	stale := staleHashHandle(t, testCitationForEntity(t, s, "c3-1"))
+
+	issues := validateADREvidence(s, "Affected Topology", "c3-1", stale, "warning", false)
+	if len(issues) != 1 || !strings.Contains(issues[0].Message, "stale cite") {
+		t.Fatalf("expected the stale-cite message when no node seals to the hash, got %+v", issues)
+	}
+	if !strings.Contains(issues[0].Hint, "refresh") {
+		t.Fatalf("expected the refresh hint for a genuinely stale hash, got %q", issues[0].Hint)
+	}
+}
+
+func TestCitationColumn_SnippetMismatchIsNotReportedAsStale(t *testing.T) {
+	s := createRichDBFixture(t)
+	handle := swapCiteSnippet(t, testCitationForEntity(t, s, "c3-1"), "a snippet nobody wrote")
+
+	issues := validateCitationColumnValue(handle, mustEntity(t, s, "c3-1"), citeOpts(s))
+	if len(issues) != 1 {
+		t.Fatalf("expected exactly one issue, got %+v", issues)
+	}
+	if strings.Contains(issues[0].Message, "stale") {
+		t.Fatalf("a fresh hash with a bad snippet must not be reported as stale: %q", issues[0].Message)
+	}
+	if !strings.Contains(issues[0].Message, "a snippet nobody wrote") ||
+		!strings.Contains(issues[0].Message, "Serve API requests") {
+		t.Fatalf("expected cited snippet vs actual node text, got %q", issues[0].Message)
+	}
+	if strings.Contains(issues[0].Hint, "refresh the handle") {
+		t.Fatalf("hint must not say refresh for a snippet mismatch: %q", issues[0].Hint)
+	}
+}
+
+// Truncation: a cite against a long node must not dump the node into the line.
+func TestCitationColumn_SnippetMismatchTruncates(t *testing.T) {
+	s := createRichDBFixture(t)
+	long := strings.Repeat("x", 400)
+	handle := swapCiteSnippet(t, testCitationForEntity(t, s, "c3-1"), long)
+
+	issues := validateCitationColumnValue(handle, mustEntity(t, s, "c3-1"), citeOpts(s))
+	if len(issues) != 1 {
+		t.Fatalf("expected exactly one issue, got %+v", issues)
+	}
+	if strings.Contains(issues[0].Message, long) {
+		t.Fatalf("message must truncate the cited snippet, got %q", issues[0].Message)
+	}
+	if len(issues[0].Message) > 400 {
+		t.Fatalf("message must stay to one readable line, got %d chars: %q", len(issues[0].Message), issues[0].Message)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// B — the invalid-handle hint must name the invocation that emits node handles
+// ---------------------------------------------------------------------------
+
+func TestADREvidence_InvalidHandleHintNamesSection(t *testing.T) {
+	s := createRichDBFixture(t)
+	entity := mustEntity(t, s, "c3-1")
+	// The ENTITY-ROOT form bare `read --cite` emits — rejected by the grammar.
+	root := entity.ID + "@v1:sha256:" + strings.Repeat("a", 64)
+
+	issues := validateADREvidence(s, "Affected Topology", "c3-1", root, "warning", false)
+	if len(issues) != 1 {
+		t.Fatalf("expected the invalid-citation issue, got %+v", issues)
+	}
+	if !strings.Contains(issues[0].Hint, "--section") {
+		t.Fatalf("hint must name --section <name> (bare --cite emits the rejected root form), got %q", issues[0].Hint)
+	}
+}
+
+func TestCitationColumn_InvalidHandleHintNamesSection(t *testing.T) {
+	s := createRichDBFixture(t)
+	root := "c3-1@v1:sha256:" + strings.Repeat("a", 64)
+
+	issues := validateCitationColumnValue(root, mustEntity(t, s, "c3-1"), citeOpts(s))
+	if len(issues) != 1 {
+		t.Fatalf("expected the invalid-citation issue, got %+v", issues)
+	}
+	if !strings.Contains(issues[0].Hint, "--section") {
+		t.Fatalf("hint must name --section <name>, got %q", issues[0].Hint)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// C — every independent finding in a row surfaces in one pass
+// ---------------------------------------------------------------------------
+
+func TestAffectedTopology_ReportsWhyAndEvidenceTogether(t *testing.T) {
+	s := createRichDBFixture(t)
+	stale := staleHashHandle(t, testCitationForEntity(t, s, "c3-1"))
+	body := adrTopoBodyWithEvidence([][4]string{{"c3-1", "container", "", stale}})
+
+	_, issues := parseADRAffectedTopology(s, body, "warning", adrSchemaHint())
+	if !hasIssue(issues, "must explain why it is affected") {
+		t.Fatalf("expected the missing-why finding, got %#v", issues)
+	}
+	if !hasIssue(issues, "stale cite") {
+		t.Fatalf("a blank Why must not hide the row's Evidence defect, got %#v", issues)
+	}
+}
+
+func TestAffectedTopology_ReportsTypeMismatchAndEvidenceTogether(t *testing.T) {
+	s := createRichDBFixture(t)
+	stale := staleHashHandle(t, testCitationForEntity(t, s, "c3-1"))
+	body := adrTopoBodyWithEvidence([][4]string{{"c3-1", "component", "boundary moves", stale}})
+
+	_, issues := parseADRAffectedTopology(s, body, "warning", adrSchemaHint())
+	if !hasIssue(issues, "type mismatch") {
+		t.Fatalf("expected the type-mismatch finding, got %#v", issues)
+	}
+	if !hasIssue(issues, "stale cite") {
+		t.Fatalf("a type mismatch must not hide the row's Evidence defect, got %#v", issues)
+	}
+}
+
+// An unresolvable Entity blocks only the entity-relative Evidence checks; the
+// cell-shape ones still run.
+func TestAffectedTopology_UnknownEntityStillReportsEvidenceShape(t *testing.T) {
+	s := createRichDBFixture(t)
+	body := adrTopoBodyWithEvidence([][4]string{{"c3-999", "component", "", "not a handle at all"}})
+
+	_, issues := parseADRAffectedTopology(s, body, "warning", adrSchemaHint())
+	if !hasIssue(issues, "unknown entity") {
+		t.Fatalf("expected the unknown-entity finding, got %#v", issues)
+	}
+	if !hasIssue(issues, "must explain why it is affected") {
+		t.Fatalf("expected the missing-why finding alongside, got %#v", issues)
+	}
+	if !hasIssue(issues, "invalid Evidence citation") {
+		t.Fatalf("expected the Evidence shape finding alongside, got %#v", issues)
+	}
+}
+
+func TestRelatedTable_ReportsWhyAndEvidenceTogether(t *testing.T) {
+	s := createRichDBFixture(t)
+	stale := staleHashHandle(t, testCitationForEntity(t, s, "ref-jwt"))
+	body := adrRelatedBody([][4]string{{"ref-jwt", "", stale, "comply"}})
+
+	_, issues := parseADRRelatedTable(s, body, "Compliance Refs", "Ref", "ref", "warning", adrSchemaHint())
+	if !hasIssue(issues, "must explain why compliance/review is required") {
+		t.Fatalf("expected the missing-why finding, got %#v", issues)
+	}
+	if !hasIssue(issues, "stale cite") {
+		t.Fatalf("a blank Why must not hide the row's Evidence defect, got %#v", issues)
+	}
+}
+
+func TestRelatedTable_ReportsTypeMismatchAndEvidenceTogether(t *testing.T) {
+	s := createRichDBFixture(t)
+	stale := staleHashHandle(t, testCitationForEntity(t, s, "c3-1"))
+	body := adrRelatedBody([][4]string{{"c3-1", "container is not a ref", stale, "comply"}})
+
+	_, issues := parseADRRelatedTable(s, body, "Compliance Refs", "Ref", "ref", "warning", adrSchemaHint())
+	if !hasIssue(issues, "type mismatch") {
+		t.Fatalf("expected the type-mismatch finding, got %#v", issues)
+	}
+	if !hasIssue(issues, "stale cite") {
+		t.Fatalf("a type mismatch must not hide the row's Evidence defect, got %#v", issues)
+	}
+}
+
+// Rows stay independent: a broken row does not consume its neighbour's findings.
+func TestAffectedTopology_RowsRemainIndependent(t *testing.T) {
+	s := createRichDBFixture(t)
+	body := adrTopoBodyWithEvidence([][4]string{
+		{"c3-999", "component", "", "not a handle at all"},
+		{"c3-2", "container", "", "also not a handle"},
+	})
+
+	_, issues := parseADRAffectedTopology(s, body, "warning", adrSchemaHint())
+	whys := 0
+	for _, issue := range issues {
+		if strings.Contains(issue.Message, "must explain why it is affected") {
+			whys++
+		}
+	}
+	if whys != 2 {
+		t.Fatalf("expected one missing-why finding per row, got %d: %#v", whys, issues)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// D — free-form cells stay typed findings (issue #94), and name the bare id
+// ---------------------------------------------------------------------------
+
+// A free-form Entity / Ref cell once nil-derefed. Pin the no-panic behaviour so
+// a regression reports as a failure, not a crashed run.
+func TestFreeFormCells_DoNotPanic(t *testing.T) {
+	s := createRichDBFixture(t)
+	freeForm := "c3-3 shared (kanna-system-prompt.ts)"
+
+	run := func(name string, fn func() []Issue) {
+		t.Helper()
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("%s panicked on a free-form cell: %v", name, r)
+			}
+		}()
+		if issues := fn(); len(issues) == 0 {
+			t.Fatalf("%s: expected a typed validation error for a free-form cell, got none", name)
+		}
+	}
+
+	run("Affected Topology", func() []Issue {
+		body := adrTopoBodyWithEvidence([][4]string{{freeForm, "component", "shared prompt moves", "N.A - none"}})
+		_, issues := parseADRAffectedTopology(s, body, "warning", adrSchemaHint())
+		return issues
+	})
+	run("Compliance Refs", func() []Issue {
+		body := adrRelatedBody([][4]string{{"ref-jwt (see kanna-system-prompt.ts)", "token policy applies", "N.A - none", "comply"}})
+		_, issues := parseADRRelatedTable(s, body, "Compliance Refs", "Ref", "ref", "warning", adrSchemaHint())
+		return issues
+	})
+}
+
+func TestAffectedTopology_FreeFormEntityCellNamesTheBareID(t *testing.T) {
+	s := createRichDBFixture(t)
+	// First token IS a known entity — the cell is decorated, not unknown.
+	body := adrTopoBodyWithEvidence([][4]string{{"c3-1 shared (kanna-system-prompt.ts)", "container", "boundary moves", "N.A - none"}})
+
+	_, issues := parseADRAffectedTopology(s, body, "warning", adrSchemaHint())
+	if hasIssue(issues, "unknown entity") {
+		t.Fatalf("c3-1 is known; the cell is decorated, not unknown: %#v", issues)
+	}
+	if !hasIssue(issues, "only the bare id") {
+		t.Fatalf("expected a bare-id finding, got %#v", issues)
+	}
+	if hint := hintForIssue(t, issues, "only the bare id"); !strings.Contains(hint, "use just c3-1") {
+		t.Fatalf("expected the hint to name the id that was found, got %q", hint)
+	}
+}
+
+func TestAffectedTopology_UnrecognisedFreeFormStaysUnknownEntity(t *testing.T) {
+	s := createRichDBFixture(t)
+	body := adrTopoBodyWithEvidence([][4]string{{"c3-3 shared (kanna-system-prompt.ts)", "component", "shared prompt moves", "N.A - none"}})
+
+	_, issues := parseADRAffectedTopology(s, body, "warning", adrSchemaHint())
+	if !hasIssue(issues, "unknown entity") {
+		t.Fatalf("no token resolves; expected the unknown-entity finding, got %#v", issues)
+	}
+}
+
+func TestRelatedTable_FreeFormRefCellNamesTheBareID(t *testing.T) {
+	s := createRichDBFixture(t)
+	body := adrRelatedBody([][4]string{{"ref-jwt (see kanna-system-prompt.ts)", "token policy applies", "N.A - none", "comply"}})
+
+	_, issues := parseADRRelatedTable(s, body, "Compliance Refs", "Ref", "ref", "warning", adrSchemaHint())
+	if hasIssue(issues, "unknown ref") {
+		t.Fatalf("ref-jwt is known; the cell is decorated, not unknown: %#v", issues)
+	}
+	if !hasIssue(issues, "only the bare id") {
+		t.Fatalf("expected a bare-id finding, got %#v", issues)
+	}
+	if hint := hintForIssue(t, issues, "only the bare id"); !strings.Contains(hint, "use just ref-jwt") {
+		t.Fatalf("expected the hint to name the id that was found, got %q", hint)
+	}
+}
+
+// evidenceNodeMatches must distinguish the two failure causes; the old bare bool
+// is what let the callers assert the wrong one.
+func TestEvidenceNodeMatches_SeparatesHashFromSnippet(t *testing.T) {
+	s := createRichDBFixture(t)
+	handle := testCitationForEntity(t, s, "c3-1")
+	nodes, err := s.NodesForEntity("c3-1")
+	if err != nil {
+		t.Fatalf("nodes for c3-1: %v", err)
+	}
+	var target *store.Node
+	for _, n := range nodes {
+		if strings.Contains(handle, n.Hash) {
+			target = n
+			break
+		}
+	}
+	if target == nil {
+		t.Fatalf("could not locate the cited node for %s", handle)
+	}
+
+	if outcome, _ := evidenceNodeMatches(s, "c3-1", target.ID, target.Hash, ""); outcome != evidenceNodeOK {
+		t.Fatalf("a current hash must match, got %v", outcome)
+	}
+	outcome, node := evidenceNodeMatches(s, "c3-1", target.ID, target.Hash, "a snippet nobody wrote")
+	if outcome != evidenceNodeSnippetMismatch {
+		t.Fatalf("a current hash with a bad snippet must report a snippet mismatch, got %v", outcome)
+	}
+	if node == nil || node.Hash != target.Hash {
+		t.Fatalf("expected the hash-matching node back so the message can show its text, got %+v", node)
+	}
+	if outcome, _ := evidenceNodeMatches(s, "c3-1", target.ID, strings.Repeat("0", 64), ""); outcome != evidenceNodeHashUnknown {
+		t.Fatalf("a hash no node seals to must report hash-unknown, got %v", outcome)
+	}
+}

--- a/cli/cmd/change.go
+++ b/cli/cmd/change.go
@@ -104,15 +104,8 @@ func RunChangeApply(opts ChangeApplyOptions, w io.Writer) error {
 	return nil
 }
 
-// writeAfterCiteRefreshHint points at the step that closes the unit. The change
-// doc's Evidence cites anchor the blocks this apply just rewrote, so they are
-// stale the moment it succeeds — by design: the accepted→done latch only fires
-// once they are refreshed and resolve fresh, which is the proof the change
-// landed. Apply knows every target it touched, so it is the cheapest place to
-// name them; without this the staleness first shows up as unexplained check
-// failures with no documented way back.
 func writeAfterCiteRefreshHint(w io.Writer, unitID string, applied []changeset.Patch) {
-	targets := patchTargets(applied)
+	targets := distinctPatchTargets(applied)
 	if len(targets) == 0 {
 		return
 	}
@@ -123,8 +116,7 @@ func writeAfterCiteRefreshHint(w io.Writer, unitID string, applied []changeset.P
 	fmt.Fprintf(w, "  c3x check --include-adr --only %s        # --fix latches accepted → done\n", unitID)
 }
 
-// patchTargets lists each fact a unit touched, once, in apply order.
-func patchTargets(patches []changeset.Patch) []string {
+func distinctPatchTargets(patches []changeset.Patch) []string {
 	seen := map[string]bool{}
 	var targets []string
 	for _, p := range patches {

--- a/cli/cmd/change.go
+++ b/cli/cmd/change.go
@@ -100,7 +100,41 @@ func RunChangeApply(opts ChangeApplyOptions, w io.Writer) error {
 	for _, p := range factPatches {
 		fmt.Fprintf(w, "applied %s → %s (%s)\n", p.Source, p.Target, p.Scope)
 	}
+	writeAfterCiteRefreshHint(w, opts.UnitID, factPatches)
 	return nil
+}
+
+// writeAfterCiteRefreshHint points at the step that closes the unit. The change
+// doc's Evidence cites anchor the blocks this apply just rewrote, so they are
+// stale the moment it succeeds — by design: the accepted→done latch only fires
+// once they are refreshed and resolve fresh, which is the proof the change
+// landed. Apply knows every target it touched, so it is the cheapest place to
+// name them; without this the staleness first shows up as unexplained check
+// failures with no documented way back.
+func writeAfterCiteRefreshHint(w io.Writer, unitID string, applied []changeset.Patch) {
+	targets := patchTargets(applied)
+	if len(targets) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "\nnext: %s now cites the pre-change blocks — refresh its Evidence to close the unit\n", unitID)
+	for _, target := range targets {
+		fmt.Fprintf(w, "  c3x read %s --section <name> --cite\n", target)
+	}
+	fmt.Fprintf(w, "  c3x check --include-adr --only %s        # --fix latches accepted → done\n", unitID)
+}
+
+// patchTargets lists each fact a unit touched, once, in apply order.
+func patchTargets(patches []changeset.Patch) []string {
+	seen := map[string]bool{}
+	var targets []string
+	for _, p := range patches {
+		if p.Target == "" || seen[p.Target] {
+			continue
+		}
+		seen[p.Target] = true
+		targets = append(targets, p.Target)
+	}
+	return targets
 }
 
 func factPatchGate(s *store.Store, c3Dir string, patches []changeset.Patch, morphed map[string]schema.Canvas) []string {

--- a/cli/cmd/change_apply_next_test.go
+++ b/cli/cmd/change_apply_next_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #113 — `change apply` invalidates the change doc's own Evidence cites.
+//
+// That is by design: Affected Topology Evidence anchors the block the unit is
+// about to rewrite, and the accepted→done latch requires those cites to resolve
+// FRESH after the apply — which is what proves the change actually landed.
+// Auto-refreshing them inside apply would make the latch prove nothing.
+//
+// What was missing is the signpost: apply said nothing, references/change.md
+// stopped at `check`, and the author discovered the staleness as a wall of
+// check failures with no documented recovery. Apply must point forward.
+
+func TestRunChangeApply_PointsAtTheAfterCiteRefresh(t *testing.T) {
+	s, c3Dir := openStoreC3(t)
+	seedRef(t, s, "ref-jwt", "Standardize token verification so components do not reinvent it.", "Use RS256 signed JWTs verified against a shared public key.", "Old rationale about asymmetric signing here.")
+	base := citeFor(t, s, "ref-jwt", "Old rationale")
+
+	writePatch(t, c3Dir, "adr-1", "01-why.patch.md",
+		"---\ntarget: ref-jwt\nscope: block\nbase: "+base+"\n---\nAsymmetric signing lets each service verify without holding the signing secret.\n")
+
+	var buf strings.Builder
+	if err := RunChangeApply(ChangeApplyOptions{Store: s, C3Dir: c3Dir, UnitID: "adr-1"}, &buf); err != nil {
+		t.Fatalf("apply: %v\noutput: %s", err, buf.String())
+	}
+	out := buf.String()
+
+	// It must name the patched target (that is where the refreshed handle comes
+	// from), the command that yields a node handle, and the unit to re-check.
+	for _, want := range []string{"ref-jwt", "--section", "--cite", "adr-1"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("apply output must point at the After-cite refresh with %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// --dry-run performs no writes, so nothing has gone stale and there is nothing
+// to refresh. Emitting the signpost there would be a false instruction.
+func TestRunChangeApply_DryRunDoesNotPointAtRefresh(t *testing.T) {
+	s, c3Dir := openStoreC3(t)
+	seedRef(t, s, "ref-jwt", "Standardize token verification so components do not reinvent it.", "Use RS256 signed JWTs verified against a shared public key.", "Old rationale about asymmetric signing here.")
+	base := citeFor(t, s, "ref-jwt", "Old rationale")
+
+	writePatch(t, c3Dir, "adr-1", "01-why.patch.md",
+		"---\ntarget: ref-jwt\nscope: block\nbase: "+base+"\n---\nAsymmetric signing lets each service verify without holding the signing secret.\n")
+
+	var buf strings.Builder
+	if err := RunChangeApply(ChangeApplyOptions{Store: s, C3Dir: c3Dir, UnitID: "adr-1", DryRun: true}, &buf); err != nil {
+		t.Fatalf("dry-run apply: %v\noutput: %s", err, buf.String())
+	}
+	if strings.Contains(buf.String(), "--cite") {
+		t.Fatalf("dry-run must not instruct a refresh — nothing was written:\n%s", buf.String())
+	}
+}

--- a/cli/cmd/change_apply_next_test.go
+++ b/cli/cmd/change_apply_next_test.go
@@ -5,17 +5,6 @@ import (
 	"testing"
 )
 
-// Issue #113 — `change apply` invalidates the change doc's own Evidence cites.
-//
-// That is by design: Affected Topology Evidence anchors the block the unit is
-// about to rewrite, and the accepted→done latch requires those cites to resolve
-// FRESH after the apply — which is what proves the change actually landed.
-// Auto-refreshing them inside apply would make the latch prove nothing.
-//
-// What was missing is the signpost: apply said nothing, references/change.md
-// stopped at `check`, and the author discovered the staleness as a wall of
-// check failures with no documented recovery. Apply must point forward.
-
 func TestRunChangeApply_PointsAtTheAfterCiteRefresh(t *testing.T) {
 	s, c3Dir := openStoreC3(t)
 	seedRef(t, s, "ref-jwt", "Standardize token verification so components do not reinvent it.", "Use RS256 signed JWTs verified against a shared public key.", "Old rationale about asymmetric signing here.")
@@ -30,18 +19,15 @@ func TestRunChangeApply_PointsAtTheAfterCiteRefresh(t *testing.T) {
 	}
 	out := buf.String()
 
-	// It must name the patched target (that is where the refreshed handle comes
-	// from), the command that yields a node handle, and the unit to re-check.
-	for _, want := range []string{"ref-jwt", "--section", "--cite", "adr-1"} {
+	wantRefreshSignpost := []string{"ref-jwt", "--section", "--cite", "adr-1"}
+	for _, want := range wantRefreshSignpost {
 		if !strings.Contains(out, want) {
 			t.Fatalf("apply output must point at the After-cite refresh with %q; got:\n%s", want, out)
 		}
 	}
 }
 
-// --dry-run performs no writes, so nothing has gone stale and there is nothing
-// to refresh. Emitting the signpost there would be a false instruction.
-func TestRunChangeApply_DryRunDoesNotPointAtRefresh(t *testing.T) {
+func TestRunChangeApply_DryRunWritesNothingSoPointsAtNoRefresh(t *testing.T) {
 	s, c3Dir := openStoreC3(t)
 	seedRef(t, s, "ref-jwt", "Standardize token verification so components do not reinvent it.", "Use RS256 signed JWTs verified against a shared public key.", "Old rationale about asymmetric signing here.")
 	base := citeFor(t, s, "ref-jwt", "Old rationale")

--- a/cli/cmd/check_enhanced.go
+++ b/cli/cmd/check_enhanced.go
@@ -1059,9 +1059,7 @@ func validateCitationColumnValue(raw string, entity *store.Entity, opts CheckOpt
 		}}
 	}
 
-	// A stale hash and a mis-copied snippet are independent causes wanting
-	// opposite remedies; report the one actually observed.
-	outcome, node := evidenceNodeMatches(opts.Store, citedEntity, nodeID, hash, snippet)
+	outcome, node := resolveEvidenceNode(opts.Store, citedEntity, nodeID, hash, snippet)
 	switch outcome {
 	case evidenceNodeOK:
 		return nil
@@ -1081,8 +1079,6 @@ func validateCitationColumnValue(raw string, entity *store.Entity, opts CheckOpt
 			Hint:     fmt.Sprintf("refresh the handle with %s", nodeCiteCommand(citedEntity)),
 		}}
 	}
-	// A snippet-less handle is a legal form (the sha256 is the anchor), so
-	// reaching here means the hash itself is stale — never "empty snippet".
 	return []Issue{{
 		Severity: "warning",
 		Entity:   entity.ID,

--- a/cli/cmd/check_enhanced.go
+++ b/cli/cmd/check_enhanced.go
@@ -1032,7 +1032,7 @@ func validateCitationColumnValue(raw string, entity *store.Entity, opts CheckOpt
 			Severity: "warning",
 			Entity:   entity.ID,
 			Message:  fmt.Sprintf("invalid citation handle: %s", raw),
-			Hint:     `expected <entity>#n<node>@v<version>:sha256:<nodeHash> "exact snippet" from c3x read --cite`,
+			Hint:     fmt.Sprintf(`expected <entity>#n<node>@v<version>:sha256:<nodeHash> "exact snippet" from %s`, nodeCiteCommand("<id>")),
 		}}
 	}
 	citedEntity := m[1]
@@ -1055,34 +1055,39 @@ func validateCitationColumnValue(raw string, entity *store.Entity, opts CheckOpt
 			Severity: "warning",
 			Entity:   entity.ID,
 			Message:  fmt.Sprintf("citation to %s cites version %d, current version is %d", citedEntity, version, cited.Version),
-			Hint:     fmt.Sprintf("refresh the handle with c3x read %s --cite", citedEntity),
+			Hint:     fmt.Sprintf("refresh the handle with %s", nodeCiteCommand(citedEntity)),
 		}}
 	}
 
-	if evidenceNodeMatches(opts.Store, citedEntity, nodeID, hash, snippet) {
+	// A stale hash and a mis-copied snippet are independent causes wanting
+	// opposite remedies; report the one actually observed.
+	outcome, node := evidenceNodeMatches(opts.Store, citedEntity, nodeID, hash, snippet)
+	switch outcome {
+	case evidenceNodeOK:
 		return nil
-	}
-	if node, err := opts.Store.GetNode(nodeID); err == nil && node.EntityID != citedEntity {
+	case evidenceNodeSnippetMismatch:
 		return []Issue{{
 			Severity: "warning",
 			Entity:   entity.ID,
-			Message:  fmt.Sprintf("citation to %s cites node %d from %s", citedEntity, nodeID, node.EntityID),
-			Hint:     fmt.Sprintf("refresh the handle with c3x read %s --cite", citedEntity),
+			Message:  fmt.Sprintf("citation to %s has a snippet that does not match: the cited sha256 is current, but that node begins %q, not %q", citedEntity, citeExcerpt(node.Content), citeExcerpt(snippet)),
+			Hint:     fmt.Sprintf("re-copy the snippet from %s, or drop it: the sha256 is the anchor and the snippet is optional", nodeCiteCommand(citedEntity)),
 		}}
 	}
-	if snippet == "" {
+	if other, err := opts.Store.GetNode(nodeID); err == nil && other.EntityID != citedEntity {
 		return []Issue{{
 			Severity: "warning",
 			Entity:   entity.ID,
-			Message:  fmt.Sprintf("citation to %s has empty snippet", citedEntity),
-			Hint:     "paste the exact quoted snippet emitted by c3x read --cite",
+			Message:  fmt.Sprintf("citation to %s cites node %d from %s", citedEntity, nodeID, other.EntityID),
+			Hint:     fmt.Sprintf("refresh the handle with %s", nodeCiteCommand(citedEntity)),
 		}}
 	}
+	// A snippet-less handle is a legal form (the sha256 is the anchor), so
+	// reaching here means the hash itself is stale — never "empty snippet".
 	return []Issue{{
 		Severity: "warning",
 		Entity:   entity.ID,
-		Message:  fmt.Sprintf("citation to %s has stale node hash or snippet", citedEntity),
-		Hint:     fmt.Sprintf("refresh the handle with c3x read %s --cite", citedEntity),
+		Message:  fmt.Sprintf("citation to %s has a stale node hash (no node of it seals to that hash)", citedEntity),
+		Hint:     fmt.Sprintf("refresh the handle with %s", nodeCiteCommand(citedEntity)),
 	}}
 }
 

--- a/cli/cmd/help.go
+++ b/cli/cmd/help.go
@@ -31,7 +31,7 @@ Normal users rarely need this after initial setup.`,
 		Name:     "read",
 		Args:     "<entity-id>",
 		OneLiner: "Output full entity content (frontmatter + body)",
-		Help: `Usage: c3x read <entity-id> [--section <name>] [--json] [--full] [--cite]
+		Help: `Usage: c3x read <entity-id> [--section <name>] [--json] [--format text] [--full] [--cite]
 
 Output the full content of an entity as markdown (default) or structured data.
 Markdown output includes YAML frontmatter + body — same format accepted by write.
@@ -42,12 +42,15 @@ Use --full to get the complete body.
 Options:
   --section <name>   Output only the named section's content
   --json             Structured JSON output outside agent mode; agent mode stays TOON
+  --format text      TOON shape with the body as a "body: |" block of real newlines,
+                     so markdown tables stay readable without unescaping \n
   --full             Disable body truncation in agent mode
   --cite             Append canonical entity or section evidence handles
 
 Examples:
   c3x read c3-101                        # full markdown output
   c3x read ref-jwt --json                # structured JSON
+  c3x read ref-jwt --format text         # structured output, body newlines intact
   c3x read c3-101 --section Goal         # just the Goal section
   c3x read c3-101 --section Goal --cite  # section content plus evidence handle
   c3x read c3-101 --full                 # full body in agent mode`,
@@ -500,6 +503,12 @@ Entity Types: container, component, ref, rule, adr (context created by init)
 
 Global Options:
   --json                     Explicit JSON compatibility outside agent mode; agent/default structured output is TOON
+  --format text              TOON shape, but multi-line values print as real newlines
+                             under a "key: |" block — no \n unescaping needed
+  --format toon              Force TOON (the default) even alongside --json
+  --format json              Force JSON even in agent mode
+                             An explicit --format wins over --json and over C3X_MODE=agent.
+                             --format mermaid is graph-only; see c3x graph --help
   --c3-dir <path>            Override .c3/ auto-detection
   --force                    Confirm advanced reset commands
   -h, --help                 Show help

--- a/cli/cmd/helpers.go
+++ b/cli/cmd/helpers.go
@@ -15,12 +15,9 @@ func isAgentMode() bool {
 	return os.Getenv("C3X_MODE") == "agent"
 }
 
-// writeJSON is the structured-output path for commands that render their own
-// payload. It is a --json path by construction, so ResolveFormat is asked with
-// jsonExplicit=true: agent mode still downgrades to TOON exactly as before, and
-// an explicit --format outranks both.
 func writeJSON(w io.Writer, v any) error {
-	switch ResolveFormat(true, isAgentMode()) {
+	const jsonExplicit = true
+	switch ResolveFormat(jsonExplicit, isAgentMode()) {
 	case FormatText:
 		out, err := toon.MarshalAnyText(v)
 		if err != nil {

--- a/cli/cmd/helpers.go
+++ b/cli/cmd/helpers.go
@@ -15,8 +15,27 @@ func isAgentMode() bool {
 	return os.Getenv("C3X_MODE") == "agent"
 }
 
+// writeJSON is the structured-output path for commands that render their own
+// payload. It is a --json path by construction, so ResolveFormat is asked with
+// jsonExplicit=true: agent mode still downgrades to TOON exactly as before, and
+// an explicit --format outranks both.
 func writeJSON(w io.Writer, v any) error {
-	if isAgentMode() {
+	switch ResolveFormat(true, isAgentMode()) {
+	case FormatText:
+		out, err := toon.MarshalAnyText(v)
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(w, out)
+		return nil
+	case FormatJSON:
+		data, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(w, string(data))
+		return nil
+	default:
 		out, err := toon.MarshalAny(v)
 		if err != nil {
 			return err
@@ -24,12 +43,4 @@ func writeJSON(w io.Writer, v any) error {
 		fmt.Fprint(w, out)
 		return nil
 	}
-	var data []byte
-	var err error
-	data, err = json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Fprintln(w, string(data))
-	return nil
 }

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -211,9 +211,6 @@ func ParseArgs(argv []string) Options {
 		}
 	}
 
-	// --format is a process-wide output selector, so publish it to the output
-	// layer. Set unconditionally: a parse without --format must clear a value
-	// left over from an earlier one.
 	setOutputFormatFlag(opts.Format)
 
 	return opts

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -211,5 +211,10 @@ func ParseArgs(argv []string) Options {
 		}
 	}
 
+	// --format is a process-wide output selector, so publish it to the output
+	// layer. Set unconditionally: a parse without --format must clear a value
+	// left over from an earlier one.
+	setOutputFormatFlag(opts.Format)
+
 	return opts
 }

--- a/cli/cmd/output.go
+++ b/cli/cmd/output.go
@@ -15,24 +15,22 @@ const (
 	FormatJSON  OutputFormat = iota // --json explicit outside agent mode
 	FormatTOON                      // default structured machine output
 	FormatHuman                     // command-specific human prose paths
-	FormatText                      // --format text: TOON shape, multi-line values as block scalars
+	FormatText
 )
 
-// outputFormatFlag holds the process-wide --format selector, published by
-// ParseArgs. Like C3X_MODE it is one choice per invocation rather than per
-// command, so ResolveFormat reads it here instead of threading a field through
-// every command's own Options struct.
 var outputFormatFlag string
 
 func setOutputFormatFlag(v string) { outputFormatFlag = v }
 
-// formatFlagValues are the accepted --format values. "mermaid" is graph-only
-// (cmd/graph.go owns that render path); ResolveFormat deliberately ignores it so
-// every other command keeps its normal default.
-var formatFlagValues = []string{"text", "toon", "json", "mermaid"}
+const (
+	formatFlagText    = "text"
+	formatFlagTOON    = "toon"
+	formatFlagJSON    = "json"
+	formatFlagMermaid = "mermaid"
+)
 
-// ValidateFormatFlag rejects an unknown --format value up front, so a typo fails
-// loudly instead of silently falling back to the default format.
+var formatFlagValues = []string{formatFlagText, formatFlagTOON, formatFlagJSON, formatFlagMermaid}
+
 func ValidateFormatFlag(v string) error {
 	if v == "" {
 		return nil
@@ -47,16 +45,13 @@ func ValidateFormatFlag(v string) error {
 }
 
 // ResolveFormat determines output format from options and environment.
-// Precedence: explicit --format > --json > C3X_MODE=agent default.
 func ResolveFormat(jsonExplicit bool, agent bool) OutputFormat {
-	// An explicit --format is a deliberate render choice and outranks both --json
-	// and the agent default — the same rule graph already applies to --format mermaid.
 	switch outputFormatFlag {
-	case "text":
+	case formatFlagText:
 		return FormatText
-	case "toon":
+	case formatFlagTOON:
 		return FormatTOON
-	case "json":
+	case formatFlagJSON:
 		return FormatJSON
 	}
 	if agent {
@@ -79,8 +74,6 @@ func (h HelpHint) String() string {
 }
 
 // WriteTableOutput writes a tabular dataset with optional help hints.
-// JSON is explicit compatibility, --format text keeps real newlines; everything
-// else uses TOON.
 func WriteTableOutput(w io.Writer, label string, data any, fields []string, format OutputFormat, hints []HelpHint) error {
 	switch format {
 	case FormatJSON:
@@ -109,8 +102,6 @@ func WriteTableOutput(w io.Writer, label string, data any, fields []string, form
 }
 
 // WriteObjectOutput writes a single object with optional help hints.
-// JSON is explicit compatibility, --format text keeps real newlines; everything
-// else uses TOON.
 func WriteObjectOutput(w io.Writer, data any, format OutputFormat, hints []HelpHint) error {
 	switch format {
 	case FormatJSON:

--- a/cli/cmd/output.go
+++ b/cli/cmd/output.go
@@ -15,10 +15,50 @@ const (
 	FormatJSON  OutputFormat = iota // --json explicit outside agent mode
 	FormatTOON                      // default structured machine output
 	FormatHuman                     // command-specific human prose paths
+	FormatText                      // --format text: TOON shape, multi-line values as block scalars
 )
 
+// outputFormatFlag holds the process-wide --format selector, published by
+// ParseArgs. Like C3X_MODE it is one choice per invocation rather than per
+// command, so ResolveFormat reads it here instead of threading a field through
+// every command's own Options struct.
+var outputFormatFlag string
+
+func setOutputFormatFlag(v string) { outputFormatFlag = v }
+
+// formatFlagValues are the accepted --format values. "mermaid" is graph-only
+// (cmd/graph.go owns that render path); ResolveFormat deliberately ignores it so
+// every other command keeps its normal default.
+var formatFlagValues = []string{"text", "toon", "json", "mermaid"}
+
+// ValidateFormatFlag rejects an unknown --format value up front, so a typo fails
+// loudly instead of silently falling back to the default format.
+func ValidateFormatFlag(v string) error {
+	if v == "" {
+		return nil
+	}
+	for _, valid := range formatFlagValues {
+		if v == valid {
+			return nil
+		}
+	}
+	return fmt.Errorf("error: unknown --format %q\nhint: valid values are %s (mermaid is graph-only)",
+		v, strings.Join(formatFlagValues, ", "))
+}
+
 // ResolveFormat determines output format from options and environment.
+// Precedence: explicit --format > --json > C3X_MODE=agent default.
 func ResolveFormat(jsonExplicit bool, agent bool) OutputFormat {
+	// An explicit --format is a deliberate render choice and outranks both --json
+	// and the agent default — the same rule graph already applies to --format mermaid.
+	switch outputFormatFlag {
+	case "text":
+		return FormatText
+	case "toon":
+		return FormatTOON
+	case "json":
+		return FormatJSON
+	}
 	if agent {
 		return FormatTOON
 	}
@@ -39,13 +79,22 @@ func (h HelpHint) String() string {
 }
 
 // WriteTableOutput writes a tabular dataset with optional help hints.
-// JSON is explicit compatibility; every other structured format uses TOON.
+// JSON is explicit compatibility, --format text keeps real newlines; everything
+// else uses TOON.
 func WriteTableOutput(w io.Writer, label string, data any, fields []string, format OutputFormat, hints []HelpHint) error {
 	switch format {
 	case FormatJSON:
 		if err := writeJSON(w, data); err != nil {
 			return err
 		}
+		writeHints(w, hints)
+		return nil
+	case FormatText:
+		out, err := toon.MarshalTableText(label, data, fields)
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(w, out)
 		writeHints(w, hints)
 		return nil
 	default:
@@ -60,13 +109,22 @@ func WriteTableOutput(w io.Writer, label string, data any, fields []string, form
 }
 
 // WriteObjectOutput writes a single object with optional help hints.
-// JSON is explicit compatibility; every other structured format uses TOON.
+// JSON is explicit compatibility, --format text keeps real newlines; everything
+// else uses TOON.
 func WriteObjectOutput(w io.Writer, data any, format OutputFormat, hints []HelpHint) error {
 	switch format {
 	case FormatJSON:
 		if err := writeJSON(w, data); err != nil {
 			return err
 		}
+		writeHints(w, hints)
+		return nil
+	case FormatText:
+		out, err := toon.MarshalObjectText(data)
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(w, out)
 		writeHints(w, hints)
 		return nil
 	default:

--- a/cli/cmd/output_text_test.go
+++ b/cli/cmd/output_text_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 )
 
-// withFormatFlag sets the process-wide --format selector for one test and
-// restores it afterwards, so format tests cannot leak into their neighbours.
 func withFormatFlag(t *testing.T, v string) {
 	t.Helper()
 	prev := outputFormatFlag
@@ -44,9 +42,7 @@ func TestResolveFormat_ExplicitTOONWinsOverJSONFlag(t *testing.T) {
 	}
 }
 
-func TestResolveFormat_MermaidLeavesGeneralPathAlone(t *testing.T) {
-	// graph owns --format mermaid (cmd/graph.go); the general writers must fall
-	// through to their normal defaults so graph's behaviour is untouched.
+func TestResolveFormat_GraphOnlyMermaidFallsThroughToNormalDefaults(t *testing.T) {
 	withFormatFlag(t, "mermaid")
 	if got := ResolveFormat(false, true); got != FormatTOON {
 		t.Errorf("agent default must stay TOON under --format mermaid, got %d", got)
@@ -99,7 +95,7 @@ func TestValidateFormatFlag_UnknownHasActionableHint(t *testing.T) {
 	}
 }
 
-func TestParseArgs_PublishesFormatFlag(t *testing.T) {
+func TestParseArgs_PublishesFormatFlagAndResetsItWhenAbsent(t *testing.T) {
 	t.Cleanup(func() { setOutputFormatFlag("") })
 
 	opts := ParseArgs([]string{"read", "c3-101", "--format", "text"})
@@ -110,7 +106,6 @@ func TestParseArgs_PublishesFormatFlag(t *testing.T) {
 		t.Errorf("ParseArgs should publish --format to the output layer, got %d", got)
 	}
 
-	// A later parse without --format must clear the selector again.
 	ParseArgs([]string{"read", "c3-101"})
 	if got := ResolveFormat(false, true); got != FormatTOON {
 		t.Errorf("parse without --format should reset to the agent default, got %d", got)
@@ -142,8 +137,7 @@ func TestWriteObjectOutput_TextKeepsRealNewlines(t *testing.T) {
 	}
 }
 
-func TestWriteObjectOutput_AgentDefaultStillTOON(t *testing.T) {
-	// Non-regression: agent mode without --format keeps the escaped TOON form.
+func TestWriteObjectOutput_AgentWithoutFormatFlagStaysEscapedTOON(t *testing.T) {
 	t.Setenv("C3X_MODE", "agent")
 	withFormatFlag(t, "")
 	type doc struct {
@@ -216,8 +210,7 @@ func TestWriteJSON_FormatJSONWinsOverAgentTOON(t *testing.T) {
 	}
 }
 
-func TestWriteJSON_AgentDefaultUnchanged(t *testing.T) {
-	// Non-regression: the agent-mode default must not move.
+func TestWriteJSON_AgentWithoutFormatFlagStaysEscapedTOON(t *testing.T) {
 	t.Setenv("C3X_MODE", "agent")
 	withFormatFlag(t, "")
 	type doc struct {

--- a/cli/cmd/output_text_test.go
+++ b/cli/cmd/output_text_test.go
@@ -1,0 +1,248 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// withFormatFlag sets the process-wide --format selector for one test and
+// restores it afterwards, so format tests cannot leak into their neighbours.
+func withFormatFlag(t *testing.T, v string) {
+	t.Helper()
+	prev := outputFormatFlag
+	setOutputFormatFlag(v)
+	t.Cleanup(func() { setOutputFormatFlag(prev) })
+}
+
+func TestResolveFormat_ExplicitTextWinsOverAgent(t *testing.T) {
+	withFormatFlag(t, "text")
+	if got := ResolveFormat(false, true); got != FormatText {
+		t.Errorf("--format text must win over agent-mode TOON, got %d", got)
+	}
+}
+
+func TestResolveFormat_ExplicitTextWinsOverJSON(t *testing.T) {
+	withFormatFlag(t, "text")
+	if got := ResolveFormat(true, false); got != FormatText {
+		t.Errorf("--format text must win over --json, got %d", got)
+	}
+}
+
+func TestResolveFormat_ExplicitJSONWinsOverAgent(t *testing.T) {
+	withFormatFlag(t, "json")
+	if got := ResolveFormat(false, true); got != FormatJSON {
+		t.Errorf("--format json must win over agent-mode TOON, got %d", got)
+	}
+}
+
+func TestResolveFormat_ExplicitTOONWinsOverJSONFlag(t *testing.T) {
+	withFormatFlag(t, "toon")
+	if got := ResolveFormat(true, false); got != FormatTOON {
+		t.Errorf("--format toon must win over --json, got %d", got)
+	}
+}
+
+func TestResolveFormat_MermaidLeavesGeneralPathAlone(t *testing.T) {
+	// graph owns --format mermaid (cmd/graph.go); the general writers must fall
+	// through to their normal defaults so graph's behaviour is untouched.
+	withFormatFlag(t, "mermaid")
+	if got := ResolveFormat(false, true); got != FormatTOON {
+		t.Errorf("agent default must stay TOON under --format mermaid, got %d", got)
+	}
+	if got := ResolveFormat(true, false); got != FormatJSON {
+		t.Errorf("--json must still win under --format mermaid, got %d", got)
+	}
+}
+
+func TestResolveFormat_NoFlagUnchanged(t *testing.T) {
+	withFormatFlag(t, "")
+	if got := ResolveFormat(false, true); got != FormatTOON {
+		t.Errorf("agent default must remain TOON, got %d", got)
+	}
+	if got := ResolveFormat(true, true); got != FormatTOON {
+		t.Errorf("agent + --json must remain TOON, got %d", got)
+	}
+	if got := ResolveFormat(true, false); got != FormatJSON {
+		t.Errorf("human + --json must remain JSON, got %d", got)
+	}
+	if got := ResolveFormat(false, false); got != FormatTOON {
+		t.Errorf("default structured output must remain TOON, got %d", got)
+	}
+}
+
+func TestValidateFormatFlag_Valid(t *testing.T) {
+	for _, v := range []string{"", "text", "toon", "json", "mermaid"} {
+		if err := ValidateFormatFlag(v); err != nil {
+			t.Errorf("--format %q should be accepted: %v", v, err)
+		}
+	}
+}
+
+func TestValidateFormatFlag_UnknownHasActionableHint(t *testing.T) {
+	err := ValidateFormatFlag("yaml")
+	if err == nil {
+		t.Fatal("unknown --format value must error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `"yaml"`) {
+		t.Errorf("error should quote the offending value\ngot: %s", msg)
+	}
+	if !strings.Contains(msg, "hint:") {
+		t.Errorf("error should carry a hint line\ngot: %s", msg)
+	}
+	for _, v := range []string{"text", "toon", "json", "mermaid"} {
+		if !strings.Contains(msg, v) {
+			t.Errorf("hint should name valid value %q\ngot: %s", v, msg)
+		}
+	}
+}
+
+func TestParseArgs_PublishesFormatFlag(t *testing.T) {
+	t.Cleanup(func() { setOutputFormatFlag("") })
+
+	opts := ParseArgs([]string{"read", "c3-101", "--format", "text"})
+	if opts.Format != "text" {
+		t.Fatalf("Format = %q", opts.Format)
+	}
+	if got := ResolveFormat(false, true); got != FormatText {
+		t.Errorf("ParseArgs should publish --format to the output layer, got %d", got)
+	}
+
+	// A later parse without --format must clear the selector again.
+	ParseArgs([]string{"read", "c3-101"})
+	if got := ResolveFormat(false, true); got != FormatTOON {
+		t.Errorf("parse without --format should reset to the agent default, got %d", got)
+	}
+}
+
+func TestWriteObjectOutput_TextKeepsRealNewlines(t *testing.T) {
+	t.Setenv("C3X_MODE", "agent")
+	withFormatFlag(t, "text")
+	type doc struct {
+		ID   string `json:"id"`
+		Body string `json:"body"`
+	}
+	v := doc{ID: "adr-20260724-slash-picker-local-only", Body: "| a | b |\n| - | - |"}
+
+	var buf bytes.Buffer
+	if err := WriteObjectOutput(&buf, v, ResolveFormat(true, isAgentMode()), nil); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if strings.Contains(out, `\n`) {
+		t.Fatalf("--format text must not emit literal backslash-n:\n%s", out)
+	}
+	if !strings.Contains(out, "id: adr-20260724-slash-picker-local-only\n") {
+		t.Errorf("ids must survive intact\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "\n  | a | b |\n  | - | - |\n") {
+		t.Errorf("markdown table should render as real lines\ngot:\n%s", out)
+	}
+}
+
+func TestWriteObjectOutput_AgentDefaultStillTOON(t *testing.T) {
+	// Non-regression: agent mode without --format keeps the escaped TOON form.
+	t.Setenv("C3X_MODE", "agent")
+	withFormatFlag(t, "")
+	type doc struct {
+		Body string `json:"body"`
+	}
+
+	var buf bytes.Buffer
+	if err := WriteObjectOutput(&buf, doc{Body: "a\nb"}, ResolveFormat(true, isAgentMode()), nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); got != "body: \"a\\nb\"\n" {
+		t.Fatalf("agent default must stay TOON, got %q", got)
+	}
+}
+
+func TestWriteTableOutput_TextKeepsTOONGrid(t *testing.T) {
+	t.Setenv("C3X_MODE", "agent")
+	withFormatFlag(t, "text")
+	type item struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+	}
+	items := []item{{ID: "c3-1", Title: "api"}}
+
+	var buf bytes.Buffer
+	if err := WriteTableOutput(&buf, "entities", items, []string{"id", "title"}, FormatText, nil); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "entities[1]{id,title}:\n") || !strings.Contains(out, "  c3-1,api\n") {
+		t.Errorf("text mode must keep the positional table grid\ngot:\n%s", out)
+	}
+}
+
+func TestWriteJSON_FormatTextWinsOverAgentTOON(t *testing.T) {
+	t.Setenv("C3X_MODE", "agent")
+	withFormatFlag(t, "text")
+	type doc struct {
+		ID   string `json:"id"`
+		Body string `json:"body"`
+	}
+
+	var buf bytes.Buffer
+	if err := writeJSON(&buf, doc{ID: "c3-101", Body: "line one\nline two"}); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if strings.Contains(out, `\n`) {
+		t.Fatalf("writeJSON under --format text must not escape newlines:\n%s", out)
+	}
+	if !strings.Contains(out, "  line one\n  line two\n") {
+		t.Errorf("body lines should be readable as-is\ngot:\n%s", out)
+	}
+}
+
+func TestWriteJSON_FormatJSONWinsOverAgentTOON(t *testing.T) {
+	t.Setenv("C3X_MODE", "agent")
+	withFormatFlag(t, "json")
+	type doc struct {
+		ID string `json:"id"`
+	}
+
+	var buf bytes.Buffer
+	if err := writeJSON(&buf, doc{ID: "c3-101"}); err != nil {
+		t.Fatal(err)
+	}
+	var got doc
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("--format json should emit JSON even in agent mode: %v\ngot:\n%s", err, buf.String())
+	}
+}
+
+func TestWriteJSON_AgentDefaultUnchanged(t *testing.T) {
+	// Non-regression: the agent-mode default must not move.
+	t.Setenv("C3X_MODE", "agent")
+	withFormatFlag(t, "")
+	type doc struct {
+		Body string `json:"body"`
+	}
+
+	var buf bytes.Buffer
+	if err := writeJSON(&buf, doc{Body: "a\nb"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); got != "body: \"a\\nb\"\n" {
+		t.Fatalf("agent writeJSON default must stay TOON, got %q", got)
+	}
+}
+
+func TestHelp_DocumentsFormatFlag(t *testing.T) {
+	var buf bytes.Buffer
+	ShowHelp("", &buf)
+	out := buf.String()
+	if !strings.Contains(out, "--format") {
+		t.Fatalf("global help must document --format\ngot:\n%s", out)
+	}
+	for _, v := range []string{"text", "toon", "json"} {
+		if !strings.Contains(out, v) {
+			t.Errorf("global help should name --format value %q", v)
+		}
+	}
+}

--- a/cli/cmd/read.go
+++ b/cli/cmd/read.go
@@ -119,7 +119,7 @@ func RunRead(opts ReadOptions, w io.Writer) error {
 				return citeErr
 			}
 			result.Citation = citation
-			nodeCitations, nodeErr := documentCitations(opts.Store, entity)
+			nodeCitations, nodeErr := documentNodeCitations(opts.Store, entity)
 			if nodeErr != nil {
 				return nodeErr
 			}
@@ -155,7 +155,7 @@ func RunRead(opts ReadOptions, w io.Writer) error {
 		if citeErr != nil {
 			return citeErr
 		}
-		nodeCitations, nodeErr := documentCitations(opts.Store, entity)
+		nodeCitations, nodeErr := documentNodeCitations(opts.Store, entity)
 		if nodeErr != nil {
 			return nodeErr
 		}
@@ -172,11 +172,9 @@ func entityCitation(entity *store.Entity) (string, error) {
 	return fmt.Sprintf("%s@v%d:sha256:%s", entity.ID, entity.Version, entity.RootMerkle), nil
 }
 
-// documentCitations returns a node handle for every citable node in the fact, in
-// document order. Bare --cite needs these alongside the entity handle: an ADR
-// Evidence cell and a block patch anchor on a node, and without this listing the
-// only way to reach a node handle is --section, which presumes a known section.
-func documentCitations(s *store.Store, entity *store.Entity) ([]string, error) {
+const wholeDocumentSectionLevel = 0
+
+func documentNodeCitations(s *store.Store, entity *store.Entity) ([]string, error) {
 	nodes, err := s.NodesForEntity(entity.ID)
 	if err != nil {
 		return nil, fmt.Errorf("error: read nodes for %s citations: %w", entity.ID, err)
@@ -186,9 +184,7 @@ func documentCitations(s *store.Store, entity *store.Entity) ([]string, error) {
 	}
 	citations := make([]string, 0)
 	for _, n := range rootNodes(nodes) {
-		// sectionLevel 0: outside any section every heading is "nested", so the
-		// whole-document listing keeps headings citable alongside body blocks.
-		collectNodeAndDescendantCitations(nodes, entity, n, 0, &citations)
+		collectNodeAndDescendantCitations(nodes, entity, n, wholeDocumentSectionLevel, &citations)
 	}
 	return citations, nil
 }
@@ -329,9 +325,6 @@ func writeCitations(w io.Writer, citations []string) {
 	}
 }
 
-// writeEntityAndNodeCitations prints both cite forms under separate labels: the
-// two are not interchangeable, so the reader has to be able to tell which patch
-// kind each one anchors.
 func writeEntityAndNodeCitations(w io.Writer, entityCite string, nodeCites []string) {
 	fmt.Fprintf(w, "\ncitation: %s\n", entityCite)
 	if len(nodeCites) == 0 {

--- a/cli/cmd/read.go
+++ b/cli/cmd/read.go
@@ -38,6 +38,7 @@ type ReadResult struct {
 	BodyTruncated  bool       `json:"body_truncated,omitempty"`
 	BodyTotalChars int        `json:"body_total_chars,omitempty"`
 	Citation       string     `json:"citation,omitempty"`
+	NodeCitations  []string   `json:"node_citations,omitempty"`
 	Help           []HelpHint `json:"help,omitempty"`
 }
 
@@ -118,6 +119,11 @@ func RunRead(opts ReadOptions, w io.Writer) error {
 				return citeErr
 			}
 			result.Citation = citation
+			nodeCitations, nodeErr := documentCitations(opts.Store, entity)
+			if nodeErr != nil {
+				return nodeErr
+			}
+			result.NodeCitations = nodeCitations
 		}
 
 		rels, _ := opts.Store.RelationshipsFrom(entity.ID)
@@ -149,7 +155,11 @@ func RunRead(opts ReadOptions, w io.Writer) error {
 		if citeErr != nil {
 			return citeErr
 		}
-		fmt.Fprintf(w, "\ncitation: %s\n", citation)
+		nodeCitations, nodeErr := documentCitations(opts.Store, entity)
+		if nodeErr != nil {
+			return nodeErr
+		}
+		writeEntityAndNodeCitations(w, citation, nodeCitations)
 	}
 	writeAgentHints(w, cascadeHintsForEntity(entity))
 	return nil
@@ -160,6 +170,27 @@ func entityCitation(entity *store.Entity) (string, error) {
 		return "", fmt.Errorf("error: %s has no versioned content hash for citation\nhint: run c3x repair, then rerun c3x read %s --cite", entity.ID, entity.ID)
 	}
 	return fmt.Sprintf("%s@v%d:sha256:%s", entity.ID, entity.Version, entity.RootMerkle), nil
+}
+
+// documentCitations returns a node handle for every citable node in the fact, in
+// document order. Bare --cite needs these alongside the entity handle: an ADR
+// Evidence cell and a block patch anchor on a node, and without this listing the
+// only way to reach a node handle is --section, which presumes a known section.
+func documentCitations(s *store.Store, entity *store.Entity) ([]string, error) {
+	nodes, err := s.NodesForEntity(entity.ID)
+	if err != nil {
+		return nil, fmt.Errorf("error: read nodes for %s citations: %w", entity.ID, err)
+	}
+	if entity.Version <= 0 {
+		return nil, fmt.Errorf("error: %s has no versioned content for citation\nhint: run c3x repair, then rerun c3x read %s --cite", entity.ID, entity.ID)
+	}
+	citations := make([]string, 0)
+	for _, n := range rootNodes(nodes) {
+		// sectionLevel 0: outside any section every heading is "nested", so the
+		// whole-document listing keeps headings citable alongside body blocks.
+		collectNodeAndDescendantCitations(nodes, entity, n, 0, &citations)
+	}
+	return citations, nil
 }
 
 func sectionCitations(s *store.Store, entity *store.Entity, sectionName string) ([]string, error) {
@@ -296,6 +327,21 @@ func writeCitations(w io.Writer, citations []string) {
 	for _, c := range citations {
 		fmt.Fprintf(w, "  %s\n", c)
 	}
+}
+
+// writeEntityAndNodeCitations prints both cite forms under separate labels: the
+// two are not interchangeable, so the reader has to be able to tell which patch
+// kind each one anchors.
+func writeEntityAndNodeCitations(w io.Writer, entityCite string, nodeCites []string) {
+	fmt.Fprintf(w, "\ncitation: %s\n", entityCite)
+	if len(nodeCites) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "node citations:")
+	for _, c := range nodeCites {
+		fmt.Fprintf(w, "  %s\n", c)
+	}
+	fmt.Fprintln(w, "hint: the citation above anchors a whole-fact patch (insert / frontmatter / retire); a node citation anchors a block patch or an ADR Evidence cell")
 }
 
 func readAvailableSections(body string) string {

--- a/cli/cmd/read_cite_test.go
+++ b/cli/cmd/read_cite_test.go
@@ -1,0 +1,191 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// nodeHandleRE matches the node-anchored cite form that block patches and ADR
+// Evidence cells require: <entity>#n<node>@v<version>:sha256:<nodeHash>.
+var nodeHandleRE = regexp.MustCompile(`c3-101#n\d+@v\d+:sha256:[a-f0-9]{64}`)
+
+// entityHandleRE matches the entity-root form that insert/frontmatter/retire
+// patches anchor on. The `@` right after the id keeps it from matching a node handle.
+var entityHandleRE = regexp.MustCompile(`c3-101@v\d+:sha256:[a-f0-9]{64}`)
+
+func TestRunRead_CiteEmitsNodeHandles(t *testing.T) {
+	s := createRichDBFixture(t)
+	var buf bytes.Buffer
+
+	if err := RunRead(ReadOptions{Store: s, ID: "c3-101", Cite: true}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+	if !entityHandleRE.MatchString(output) {
+		t.Errorf("entity-root handle missing from bare --cite output:\n%s", output)
+	}
+	handles := nodeHandleRE.FindAllString(output, -1)
+	if len(handles) == 0 {
+		t.Fatalf("bare --cite emitted no node handles; an Evidence cell cannot be built from this output:\n%s", output)
+	}
+	if !strings.Contains(output, `"Handle authentication behavior for API requests."`) {
+		t.Errorf("node handles should carry their source snippet:\n%s", output)
+	}
+}
+
+func TestRunRead_CiteLabelsBothHandleKinds(t *testing.T) {
+	s := createRichDBFixture(t)
+	var buf bytes.Buffer
+
+	if err := RunRead(ReadOptions{Store: s, ID: "c3-101", Cite: true}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+	// The entity handle keeps its existing "citation: <handle>" shape.
+	if !strings.Contains(output, "citation: c3-101@v1:sha256:") {
+		t.Errorf("entity citation line changed shape:\n%s", output)
+	}
+	if !strings.Contains(output, "node citations:") {
+		t.Errorf("node handles should be listed under their own label:\n%s", output)
+	}
+	if !strings.Contains(output, "block patch") || !strings.Contains(output, "Evidence") {
+		t.Errorf("output should say what the node handles anchor:\n%s", output)
+	}
+}
+
+func TestRunRead_CiteJSONCarriesNodeCitations(t *testing.T) {
+	s := createRichDBFixture(t)
+	var buf bytes.Buffer
+
+	if err := RunRead(ReadOptions{Store: s, ID: "c3-101", JSON: true, Cite: true}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	var result ReadResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("JSON parse: %v", err)
+	}
+	// Citation stays the entity-root handle so existing consumers keep working.
+	if !entityHandleRE.MatchString(result.Citation) {
+		t.Errorf("citation = %q, want entity-root handle", result.Citation)
+	}
+	if len(result.NodeCitations) == 0 {
+		t.Fatalf("node_citations empty: %s", buf.String())
+	}
+	for _, c := range result.NodeCitations {
+		if !nodeHandleRE.MatchString(c) {
+			t.Errorf("node citation %q is not a node handle", c)
+		}
+	}
+	// The JSON key must be present on the wire, not just on the struct.
+	var raw map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+		t.Fatalf("JSON parse: %v", err)
+	}
+	if _, ok := raw["node_citations"]; !ok {
+		t.Errorf("node_citations key missing from JSON: %s", buf.String())
+	}
+}
+
+func TestRunRead_CiteWithoutFlagEmitsNoCitations(t *testing.T) {
+	s := createRichDBFixture(t)
+	var buf bytes.Buffer
+
+	if err := RunRead(ReadOptions{Store: s, ID: "c3-101", JSON: true}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+		t.Fatalf("JSON parse: %v", err)
+	}
+	if _, ok := raw["node_citations"]; ok {
+		t.Errorf("node_citations should be omitted without --cite: %s", buf.String())
+	}
+}
+
+// TestRunRead_CiteCoversEverySection proves the bare listing spans the whole
+// document: every handle --section --cite yields is present in it.
+func TestRunRead_CiteCoversEverySection(t *testing.T) {
+	s := createRichDBFixture(t)
+	var all bytes.Buffer
+	if err := RunRead(ReadOptions{Store: s, ID: "c3-101", JSON: true, Cite: true}, &all); err != nil {
+		t.Fatal(err)
+	}
+	var doc ReadResult
+	if err := json.Unmarshal(all.Bytes(), &doc); err != nil {
+		t.Fatalf("JSON parse: %v", err)
+	}
+	have := make(map[string]bool, len(doc.NodeCitations))
+	for _, c := range doc.NodeCitations {
+		have[c] = true
+	}
+
+	for _, section := range []string{"Goal", "Purpose", "Parent Fit", "Business Flow"} {
+		var sec bytes.Buffer
+		if err := RunRead(ReadOptions{Store: s, ID: "c3-101", Section: section, JSON: true, Cite: true}, &sec); err != nil {
+			t.Fatalf("section %q: %v", section, err)
+		}
+		var sr ReadSectionResult
+		if err := json.Unmarshal(sec.Bytes(), &sr); err != nil {
+			t.Fatalf("section %q JSON parse: %v", section, err)
+		}
+		if len(sr.Citations) == 0 {
+			t.Fatalf("section %q produced no citations to compare", section)
+		}
+		for _, c := range sr.Citations {
+			if !have[c] {
+				t.Errorf("section %q citation missing from whole-document listing: %s", section, c)
+			}
+		}
+	}
+}
+
+// TestRunRead_SectionCiteShapeUnchanged guards the documented rebase workflow:
+// --section --cite still emits section node handles only, with no entity root.
+func TestRunRead_SectionCiteShapeUnchanged(t *testing.T) {
+	s := createRichDBFixture(t)
+	var buf bytes.Buffer
+
+	if err := RunRead(ReadOptions{Store: s, ID: "c3-101", Section: "Goal", Cite: true}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "citation: c3-101#n") {
+		t.Errorf("section citation line changed shape:\n%s", output)
+	}
+	if entityHandleRE.MatchString(output) {
+		t.Errorf("section --cite must not emit the entity-root handle:\n%s", output)
+	}
+	if strings.Contains(output, "node citations:") {
+		t.Errorf("section --cite should keep its existing single-citation label:\n%s", output)
+	}
+}
+
+func TestRunRead_SectionCiteJSONShapeUnchanged(t *testing.T) {
+	s := createRichDBFixture(t)
+	var buf bytes.Buffer
+
+	if err := RunRead(ReadOptions{Store: s, ID: "c3-101", Section: "Goal", JSON: true, Cite: true}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+		t.Fatalf("JSON parse: %v", err)
+	}
+	for _, key := range []string{"citation", "node_citations"} {
+		if _, ok := raw[key]; ok {
+			t.Errorf("section --cite JSON gained unexpected key %q: %s", key, buf.String())
+		}
+	}
+	if _, ok := raw["citations"]; !ok {
+		t.Errorf("section --cite JSON lost citations: %s", buf.String())
+	}
+}

--- a/cli/cmd/read_cite_test.go
+++ b/cli/cmd/read_cite_test.go
@@ -8,12 +8,9 @@ import (
 	"testing"
 )
 
-// nodeHandleRE matches the node-anchored cite form that block patches and ADR
-// Evidence cells require: <entity>#n<node>@v<version>:sha256:<nodeHash>.
 var nodeHandleRE = regexp.MustCompile(`c3-101#n\d+@v\d+:sha256:[a-f0-9]{64}`)
 
-// entityHandleRE matches the entity-root form that insert/frontmatter/retire
-// patches anchor on. The `@` right after the id keeps it from matching a node handle.
+// The `@` directly after the id is what keeps this from also matching a node handle.
 var entityHandleRE = regexp.MustCompile(`c3-101@v\d+:sha256:[a-f0-9]{64}`)
 
 func TestRunRead_CiteEmitsNodeHandles(t *testing.T) {
@@ -46,7 +43,6 @@ func TestRunRead_CiteLabelsBothHandleKinds(t *testing.T) {
 	}
 
 	output := buf.String()
-	// The entity handle keeps its existing "citation: <handle>" shape.
 	if !strings.Contains(output, "citation: c3-101@v1:sha256:") {
 		t.Errorf("entity citation line changed shape:\n%s", output)
 	}
@@ -70,7 +66,6 @@ func TestRunRead_CiteJSONCarriesNodeCitations(t *testing.T) {
 	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
 		t.Fatalf("JSON parse: %v", err)
 	}
-	// Citation stays the entity-root handle so existing consumers keep working.
 	if !entityHandleRE.MatchString(result.Citation) {
 		t.Errorf("citation = %q, want entity-root handle", result.Citation)
 	}
@@ -82,12 +77,11 @@ func TestRunRead_CiteJSONCarriesNodeCitations(t *testing.T) {
 			t.Errorf("node citation %q is not a node handle", c)
 		}
 	}
-	// The JSON key must be present on the wire, not just on the struct.
-	var raw map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+	var wireFields map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &wireFields); err != nil {
 		t.Fatalf("JSON parse: %v", err)
 	}
-	if _, ok := raw["node_citations"]; !ok {
+	if _, ok := wireFields["node_citations"]; !ok {
 		t.Errorf("node_citations key missing from JSON: %s", buf.String())
 	}
 }
@@ -100,18 +94,16 @@ func TestRunRead_CiteWithoutFlagEmitsNoCitations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var raw map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+	var wireFields map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &wireFields); err != nil {
 		t.Fatalf("JSON parse: %v", err)
 	}
-	if _, ok := raw["node_citations"]; ok {
+	if _, ok := wireFields["node_citations"]; ok {
 		t.Errorf("node_citations should be omitted without --cite: %s", buf.String())
 	}
 }
 
-// TestRunRead_CiteCoversEverySection proves the bare listing spans the whole
-// document: every handle --section --cite yields is present in it.
-func TestRunRead_CiteCoversEverySection(t *testing.T) {
+func TestRunRead_CiteListsEveryHandleSectionCiteYields(t *testing.T) {
 	s := createRichDBFixture(t)
 	var all bytes.Buffer
 	if err := RunRead(ReadOptions{Store: s, ID: "c3-101", JSON: true, Cite: true}, &all); err != nil {
@@ -146,9 +138,7 @@ func TestRunRead_CiteCoversEverySection(t *testing.T) {
 	}
 }
 
-// TestRunRead_SectionCiteShapeUnchanged guards the documented rebase workflow:
-// --section --cite still emits section node handles only, with no entity root.
-func TestRunRead_SectionCiteShapeUnchanged(t *testing.T) {
+func TestRunRead_SectionCiteStillEmitsSectionNodeHandlesOnly(t *testing.T) {
 	s := createRichDBFixture(t)
 	var buf bytes.Buffer
 
@@ -176,16 +166,16 @@ func TestRunRead_SectionCiteJSONShapeUnchanged(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var raw map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+	var wireFields map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &wireFields); err != nil {
 		t.Fatalf("JSON parse: %v", err)
 	}
 	for _, key := range []string{"citation", "node_citations"} {
-		if _, ok := raw[key]; ok {
+		if _, ok := wireFields[key]; ok {
 			t.Errorf("section --cite JSON gained unexpected key %q: %s", key, buf.String())
 		}
 	}
-	if _, ok := raw["citations"]; !ok {
+	if _, ok := wireFields["citations"]; !ok {
 		t.Errorf("section --cite JSON lost citations: %s", buf.String())
 	}
 }

--- a/cli/cmd/strict_component_docs.go
+++ b/cli/cmd/strict_component_docs.go
@@ -156,10 +156,6 @@ func validateStrictDoc(defs []schema.SectionDef, body string, severity string) [
 		}
 		table, err := markdown.ParseTable(section.Content)
 		if err != nil {
-			// Carry the parser's cause: it names the offending row and the
-			// expected vs actual cell count. The bare section name sends the
-			// author hand-diffing against the schema for something the
-			// validator already knows.
 			issues = append(issues, strictIssue(severity, fmt.Sprintf("invalid required table: %s — %v", sectionName, err), hint))
 			continue
 		}

--- a/cli/cmd/strict_component_docs.go
+++ b/cli/cmd/strict_component_docs.go
@@ -156,7 +156,11 @@ func validateStrictDoc(defs []schema.SectionDef, body string, severity string) [
 		}
 		table, err := markdown.ParseTable(section.Content)
 		if err != nil {
-			issues = append(issues, strictIssue(severity, fmt.Sprintf("invalid required table: %s", sectionName), hint))
+			// Carry the parser's cause: it names the offending row and the
+			// expected vs actual cell count. The bare section name sends the
+			// author hand-diffing against the schema for something the
+			// validator already knows.
+			issues = append(issues, strictIssue(severity, fmt.Sprintf("invalid required table: %s — %v", sectionName, err), hint))
 			continue
 		}
 		if !slices.Equal(table.Headers, headers) {

--- a/cli/cmd/table_shape_error_test.go
+++ b/cli/cmd/table_shape_error_test.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #116 item 2 — a table-shape rejection must name the offending row.
+//
+// markdown.ParseTable already knows the row number and the expected vs actual
+// cell counts; every validator used to drop that error and report only
+// "invalid required table: <Name>", whose hint listed section names — which is
+// never the problem. Diagnosis was by hand-diffing the row against the schema.
+// These tests pin the cause through each validator that surfaces the rejection.
+
+// dropLastCell rewrites the first data row of the named table section so it
+// carries one cell fewer than its header — the exact reported shape (a row with
+// 4 cells where the canvas wants 5).
+func dropLastCell(t *testing.T, body, sectionName string) string {
+	t.Helper()
+	lines := strings.Split(body, "\n")
+	inSection := false
+	seenSeparator := false
+	for i, line := range lines {
+		switch {
+		case strings.HasPrefix(line, "## "):
+			inSection = strings.TrimSpace(strings.TrimPrefix(line, "## ")) == sectionName
+			seenSeparator = false
+		case inSection && strings.HasPrefix(line, "| ---"):
+			seenSeparator = true
+		case inSection && seenSeparator && strings.HasPrefix(line, "|"):
+			cells := strings.Split(strings.Trim(strings.TrimSpace(line), "|"), "|")
+			if len(cells) < 2 {
+				t.Fatalf("row in %s has too few cells to shorten: %q", sectionName, line)
+			}
+			lines[i] = "|" + strings.Join(cells[:len(cells)-1], "|") + "|"
+			return strings.Join(lines, "\n")
+		}
+	}
+	t.Fatalf("no data row found in section %q", sectionName)
+	return ""
+}
+
+// assertNamesOffendingRow finds the table-shape rejection for a section and
+// requires it to carry the cause, not just the section name.
+func assertNamesOffendingRow(t *testing.T, issues []Issue, sectionName, rowFragment string, wantCols, gotCols string) {
+	t.Helper()
+	marker := "invalid required table: " + sectionName
+	for _, issue := range issues {
+		if !strings.Contains(issue.Message, marker) {
+			continue
+		}
+		text := issue.Message + " " + issue.Hint
+		for _, want := range []string{"row", wantCols, gotCols, rowFragment} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("table-shape rejection must name %q; got message=%q hint=%q", want, issue.Message, issue.Hint)
+			}
+		}
+		return
+	}
+	t.Fatalf("no %q issue; got %+v", marker, issues)
+}
+
+func TestTableShapeError_StrictDocNamesOffendingRow(t *testing.T) {
+	body := dropLastCell(t, strictComponentBody("auth", "Own authentication for API requests."), "Governance")
+	assertNamesOffendingRow(t, validateStrictComponentDoc(body, "error"), "Governance", "ref-jwt", "5", "4")
+}
+
+func TestTableShapeError_WriteValidationNamesOffendingRow(t *testing.T) {
+	body := dropLastCell(t, strictComponentBody("auth", "Own authentication for API requests."), "Governance")
+	assertNamesOffendingRow(t, validateBodyContent(body, "component"), "Governance", "ref-jwt", "5", "4")
+}
+
+func TestTableShapeError_ADRCreationNamesOffendingRow(t *testing.T) {
+	body := strings.Join([]string{
+		"# Use Go",
+		"",
+		"## Affected Topology",
+		"",
+		"| Entity | Type | Why affected | Governance review | Evidence |",
+		"| --- | --- | --- | --- | --- |",
+		"| c3-101 | component | New parameter on the builder | Codemap updated |",
+		"",
+	}, "\n")
+	assertNamesOffendingRow(t, validateADRCreationBody(body), "Affected Topology", "c3-101", "5", "4")
+}

--- a/cli/cmd/table_shape_error_test.go
+++ b/cli/cmd/table_shape_error_test.go
@@ -5,18 +5,7 @@ import (
 	"testing"
 )
 
-// Issue #116 item 2 — a table-shape rejection must name the offending row.
-//
-// markdown.ParseTable already knows the row number and the expected vs actual
-// cell counts; every validator used to drop that error and report only
-// "invalid required table: <Name>", whose hint listed section names — which is
-// never the problem. Diagnosis was by hand-diffing the row against the schema.
-// These tests pin the cause through each validator that surfaces the rejection.
-
-// dropLastCell rewrites the first data row of the named table section so it
-// carries one cell fewer than its header — the exact reported shape (a row with
-// 4 cells where the canvas wants 5).
-func dropLastCell(t *testing.T, body, sectionName string) string {
+func dropLastCellFromFirstDataRow(t *testing.T, body, sectionName string) string {
 	t.Helper()
 	lines := strings.Split(body, "\n")
 	inSection := false
@@ -41,13 +30,11 @@ func dropLastCell(t *testing.T, body, sectionName string) string {
 	return ""
 }
 
-// assertNamesOffendingRow finds the table-shape rejection for a section and
-// requires it to carry the cause, not just the section name.
 func assertNamesOffendingRow(t *testing.T, issues []Issue, sectionName, rowFragment string, wantCols, gotCols string) {
 	t.Helper()
-	marker := "invalid required table: " + sectionName
+	tableShapeRejection := "invalid required table: " + sectionName
 	for _, issue := range issues {
-		if !strings.Contains(issue.Message, marker) {
+		if !strings.Contains(issue.Message, tableShapeRejection) {
 			continue
 		}
 		text := issue.Message + " " + issue.Hint
@@ -58,16 +45,16 @@ func assertNamesOffendingRow(t *testing.T, issues []Issue, sectionName, rowFragm
 		}
 		return
 	}
-	t.Fatalf("no %q issue; got %+v", marker, issues)
+	t.Fatalf("no %q issue; got %+v", tableShapeRejection, issues)
 }
 
 func TestTableShapeError_StrictDocNamesOffendingRow(t *testing.T) {
-	body := dropLastCell(t, strictComponentBody("auth", "Own authentication for API requests."), "Governance")
+	body := dropLastCellFromFirstDataRow(t, strictComponentBody("auth", "Own authentication for API requests."), "Governance")
 	assertNamesOffendingRow(t, validateStrictComponentDoc(body, "error"), "Governance", "ref-jwt", "5", "4")
 }
 
 func TestTableShapeError_WriteValidationNamesOffendingRow(t *testing.T) {
-	body := dropLastCell(t, strictComponentBody("auth", "Own authentication for API requests."), "Governance")
+	body := dropLastCellFromFirstDataRow(t, strictComponentBody("auth", "Own authentication for API requests."), "Governance")
 	assertNamesOffendingRow(t, validateBodyContent(body, "component"), "Governance", "ref-jwt", "5", "4")
 }
 

--- a/cli/cmd/write.go
+++ b/cli/cmd/write.go
@@ -276,7 +276,7 @@ func validateBodyContentWithDefinition(body, entityType string, schemaSections [
 			if !ok {
 				issues = append(issues, Issue{
 					Severity: "error",
-					Message:  fmt.Sprintf("invalid required table: %s", sec.Name),
+					Message:  fmt.Sprintf("invalid required table: %s — %v", sec.Name, err),
 					Hint:     fmt.Sprintf("run 'c3x schema %s' for the %s table columns", entityType, sec.Name),
 				})
 				continue
@@ -293,9 +293,12 @@ func validateBodyContentWithDefinition(body, entityType string, schemaSections [
 				}
 			}
 			if !missingColumns {
+				// Headers are fine, so the fault is a row — the parser names
+				// which one and its cell count. Reporting only the section name
+				// here is what forced hand-diffing against the schema.
 				issues = append(issues, Issue{
 					Severity: "error",
-					Message:  fmt.Sprintf("invalid required table: %s", sec.Name),
+					Message:  fmt.Sprintf("invalid required table: %s — %v", sec.Name, err),
 					Hint:     fmt.Sprintf("run 'c3x schema %s' for the %s table columns", entityType, sec.Name),
 				})
 			}

--- a/cli/cmd/write.go
+++ b/cli/cmd/write.go
@@ -293,9 +293,6 @@ func validateBodyContentWithDefinition(body, entityType string, schemaSections [
 				}
 			}
 			if !missingColumns {
-				// Headers are fine, so the fault is a row — the parser names
-				// which one and its cell count. Reporting only the section name
-				// here is what forced hand-diffing against the schema.
 				issues = append(issues, Issue{
 					Severity: "error",
 					Message:  fmt.Sprintf("invalid required table: %s — %v", sec.Name, err),

--- a/cli/format_flag_test.go
+++ b/cli/format_flag_test.go
@@ -27,8 +27,8 @@ func TestRun_UnknownFormatValueErrors(t *testing.T) {
 func TestRun_KnownFormatValuesAccepted(t *testing.T) {
 	for _, v := range []string{"text", "toon", "json", "mermaid"} {
 		var buf bytes.Buffer
-		// No .c3/ here, so the command still fails — just not on --format.
-		err := run([]string{"--c3-dir", t.TempDir(), "list", "--format", v}, &buf)
+		dirWithoutC3 := t.TempDir()
+		err := run([]string{"--c3-dir", dirWithoutC3, "list", "--format", v}, &buf)
 		if err != nil && strings.Contains(err.Error(), "--format") {
 			t.Errorf("--format %s should be accepted, got: %v", v, err)
 		}

--- a/cli/format_flag_test.go
+++ b/cli/format_flag_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRun_UnknownFormatValueErrors(t *testing.T) {
+	var buf bytes.Buffer
+	err := run([]string{"--c3-dir", t.TempDir(), "list", "--format", "yaml"}, &buf)
+	if err == nil {
+		t.Fatal("unknown --format value should fail before any command runs")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `unknown --format "yaml"`) {
+		t.Errorf("error should name the bad value\ngot: %s", msg)
+	}
+	if !strings.Contains(msg, "hint: valid values are text, toon, json, mermaid") {
+		t.Errorf("error should list valid values\ngot: %s", msg)
+	}
+	if buf.Len() > 0 {
+		t.Errorf("nothing should be written on a bad --format, got: %q", buf.String())
+	}
+}
+
+func TestRun_KnownFormatValuesAccepted(t *testing.T) {
+	for _, v := range []string{"text", "toon", "json", "mermaid"} {
+		var buf bytes.Buffer
+		// No .c3/ here, so the command still fails — just not on --format.
+		err := run([]string{"--c3-dir", t.TempDir(), "list", "--format", v}, &buf)
+		if err != nil && strings.Contains(err.Error(), "--format") {
+			t.Errorf("--format %s should be accepted, got: %v", v, err)
+		}
+	}
+}

--- a/cli/internal/content/parse.go
+++ b/cli/internal/content/parse.go
@@ -226,13 +226,30 @@ func extractRawLines(n ast.Node, source []byte) string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
-// extractTableRow gets pipe-separated cell text.
+// extractTableRow gets pipe-separated cell text. Cells are read from their raw
+// source segments, not Text(), so inline markup (code spans, emphasis, links)
+// inside a cell survives the round-trip.
 func extractTableRow(n ast.Node, source []byte) string {
 	var cells []string
 	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
-		cells = append(cells, strings.TrimSpace(string(c.Text(source))))
+		cells = append(cells, extractTableCell(c, source))
 	}
 	return strings.Join(cells, " | ")
+}
+
+// extractTableCell returns a cell's raw source, falling back to inline text for
+// a cell that reports no source segments.
+func extractTableCell(n ast.Node, source []byte) string {
+	lines := n.Lines()
+	if lines.Len() == 0 {
+		return strings.TrimSpace(string(n.Text(source)))
+	}
+	var b strings.Builder
+	for i := range lines.Len() {
+		line := lines.At(i)
+		b.Write(line.Value(source))
+	}
+	return strings.TrimSpace(b.String())
 }
 
 func extractListItem(n ast.Node, source []byte) string {

--- a/cli/internal/content/parse.go
+++ b/cli/internal/content/parse.go
@@ -226,9 +226,7 @@ func extractRawLines(n ast.Node, source []byte) string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
-// extractTableRow gets pipe-separated cell text. Cells are read from their raw
-// source segments, not Text(), so inline markup (code spans, emphasis, links)
-// inside a cell survives the round-trip.
+// extractTableRow gets pipe-separated cell text.
 func extractTableRow(n ast.Node, source []byte) string {
 	var cells []string
 	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
@@ -237,14 +235,20 @@ func extractTableRow(n ast.Node, source []byte) string {
 	return strings.Join(cells, " | ")
 }
 
-// extractTableCell returns a cell's raw source, falling back to inline text for
-// a cell that reports no source segments.
 func extractTableCell(n ast.Node, source []byte) string {
-	lines := n.Lines()
-	if lines.Len() == 0 {
-		return strings.TrimSpace(string(n.Text(source)))
+	if n.Lines().Len() == 0 {
+		return extractCellInlineText(n, source)
 	}
+	return extractCellMarkupPreservingSource(n, source)
+}
+
+func extractCellInlineText(n ast.Node, source []byte) string {
+	return strings.TrimSpace(string(n.Text(source)))
+}
+
+func extractCellMarkupPreservingSource(n ast.Node, source []byte) string {
 	var b strings.Builder
+	lines := n.Lines()
 	for i := range lines.Len() {
 		line := lines.At(i)
 		b.Write(line.Value(source))

--- a/cli/internal/content/parse_test.go
+++ b/cli/internal/content/parse_test.go
@@ -157,6 +157,58 @@ func TestParse_Table(t *testing.T) {
 	}
 }
 
+func TestParse_TableCellPreservesCodeSpan(t *testing.T) {
+	md := "| Op | Note |\n| --- | --- |\n| `chat.send` | use `--json` |\n"
+	tree := ParseMarkdown("comp-1", md)
+	if len(tree.Nodes) != 3 {
+		t.Fatalf("expected 3 nodes (table + header + row), got %d", len(tree.Nodes))
+	}
+	if tree.Nodes[2].Content != "`chat.send` | use `--json`" {
+		t.Errorf("row content: %q", tree.Nodes[2].Content)
+	}
+}
+
+func TestParse_TableCellPreservesEmphasisAndLink(t *testing.T) {
+	md := "| A | B |\n| --- | --- |\n| got *emph* and [a](b) | **bold** |\n"
+	tree := ParseMarkdown("comp-1", md)
+	if len(tree.Nodes) != 3 {
+		t.Fatalf("expected 3 nodes, got %d", len(tree.Nodes))
+	}
+	if tree.Nodes[2].Content != "got *emph* and [a](b) | **bold**" {
+		t.Errorf("row content: %q", tree.Nodes[2].Content)
+	}
+}
+
+func TestParse_TableHeaderPreservesMarkup(t *testing.T) {
+	md := "| `id` | *label* |\n| --- | --- |\n| a | b |\n"
+	tree := ParseMarkdown("comp-1", md)
+	if len(tree.Nodes) != 3 {
+		t.Fatalf("expected 3 nodes, got %d", len(tree.Nodes))
+	}
+	if tree.Nodes[1].Content != "`id` | *label*" {
+		t.Errorf("header content: %q", tree.Nodes[1].Content)
+	}
+}
+
+// Plain cells must keep byte-identical content (and therefore the same node
+// hash) — hashes are seals, so unmarked-up tables must not churn.
+func TestParse_TablePlainCellsUnchanged(t *testing.T) {
+	md := "| Name | Type |\n| --- | --- |\n| auth | service |\n"
+	tree := ParseMarkdown("comp-1", md)
+	if len(tree.Nodes) != 3 {
+		t.Fatalf("expected 3 nodes, got %d", len(tree.Nodes))
+	}
+	if tree.Nodes[1].Content != "Name | Type" {
+		t.Errorf("header content: %q", tree.Nodes[1].Content)
+	}
+	if tree.Nodes[2].Content != "auth | service" {
+		t.Errorf("row content: %q", tree.Nodes[2].Content)
+	}
+	if got, want := tree.Nodes[2].Hash, store.ComputeNodeHash("auth | service", "table_row"); got != want {
+		t.Errorf("row hash: got %s, want %s", got, want)
+	}
+}
+
 func TestParse_CodeBlock(t *testing.T) {
 	md := "```go\nfunc main() {}\n```\n"
 	tree := ParseMarkdown("comp-1", md)

--- a/cli/internal/content/parse_test.go
+++ b/cli/internal/content/parse_test.go
@@ -190,9 +190,7 @@ func TestParse_TableHeaderPreservesMarkup(t *testing.T) {
 	}
 }
 
-// Plain cells must keep byte-identical content (and therefore the same node
-// hash) — hashes are seals, so unmarked-up tables must not churn.
-func TestParse_TablePlainCellsUnchanged(t *testing.T) {
+func TestParse_TablePlainCellsKeepContentAndNodeHash(t *testing.T) {
 	md := "| Name | Type |\n| --- | --- |\n| auth | service |\n"
 	tree := ParseMarkdown("comp-1", md)
 	if len(tree.Nodes) != 3 {

--- a/cli/internal/markdown/markdown.go
+++ b/cli/internal/markdown/markdown.go
@@ -122,7 +122,6 @@ func ParseTable(markdown string) (*Table, error) {
 	for rowIdx, line := range filtered[2:] {
 		cells := parseCells(line)
 		if len(cells) != len(headers) {
-			// Name the row so the caller doesn't have to hand-diff the table
 			return nil, fmt.Errorf("column count mismatch in data row %d: header has %d columns, row has %d: %s",
 				rowIdx+1, len(headers), len(cells), strings.TrimSpace(line))
 		}
@@ -156,8 +155,7 @@ func parseCells(line string) []string {
 	var cells []string
 	var current strings.Builder
 	for i := 0; i < len(line); i++ {
-		if line[i] == '\\' && i+1 < len(line) && line[i+1] == '|' {
-			// GFM escape: \| is a literal pipe in the cell value, not a delimiter
+		if isEscapedPipeAt(line, i) {
 			current.WriteByte('|')
 			i++ // skip the pipe
 		} else if line[i] == '|' {
@@ -172,13 +170,14 @@ func parseCells(line string) []string {
 	return cells
 }
 
-// escapeCell escapes literal pipes in a cell value so they survive serialisation
-// as content instead of splitting the row. Inverse of the \| handling in parseCells.
+func isEscapedPipeAt(line string, i int) bool {
+	return line[i] == '\\' && i+1 < len(line) && line[i+1] == '|'
+}
+
 func escapeCell(value string) string {
 	return strings.ReplaceAll(value, "|", `\|`)
 }
 
-// escapeCells applies escapeCell to every value, returning a new slice.
 func escapeCells(values []string) []string {
 	out := make([]string, len(values))
 	for i, v := range values {

--- a/cli/internal/markdown/markdown.go
+++ b/cli/internal/markdown/markdown.go
@@ -100,7 +100,7 @@ func ParseTable(markdown string) (*Table, error) {
 	// Parse header row
 	headers := parseCells(filtered[0])
 	if len(headers) == 0 {
-		return nil, fmt.Errorf("not a valid markdown table: no headers found")
+		return nil, fmt.Errorf("not a valid markdown table: no headers found in header row: %s", strings.TrimSpace(filtered[0]))
 	}
 
 	// Verify separator row
@@ -114,15 +114,17 @@ func ParseTable(markdown string) (*Table, error) {
 		}
 	}
 	if !isSeparator {
-		return nil, fmt.Errorf("not a valid markdown table: second row is not a separator")
+		return nil, fmt.Errorf("not a valid markdown table: second row is not a separator: %s", strings.TrimSpace(filtered[1]))
 	}
 
 	// Parse data rows
 	var rows []map[string]string
-	for _, line := range filtered[2:] {
+	for rowIdx, line := range filtered[2:] {
 		cells := parseCells(line)
 		if len(cells) != len(headers) {
-			return nil, fmt.Errorf("column count mismatch: header has %d columns, row has %d", len(headers), len(cells))
+			// Name the row so the caller doesn't have to hand-diff the table
+			return nil, fmt.Errorf("column count mismatch in data row %d: header has %d columns, row has %d: %s",
+				rowIdx+1, len(headers), len(cells), strings.TrimSpace(line))
 		}
 		row := make(map[string]string, len(headers))
 		for i, h := range headers {
@@ -155,7 +157,8 @@ func parseCells(line string) []string {
 	var current strings.Builder
 	for i := 0; i < len(line); i++ {
 		if line[i] == '\\' && i+1 < len(line) && line[i+1] == '|' {
-			current.WriteString(`\|`)
+			// GFM escape: \| is a literal pipe in the cell value, not a delimiter
+			current.WriteByte('|')
 			i++ // skip the pipe
 		} else if line[i] == '|' {
 			cells = append(cells, strings.TrimSpace(current.String()))
@@ -169,13 +172,28 @@ func parseCells(line string) []string {
 	return cells
 }
 
+// escapeCell escapes literal pipes in a cell value so they survive serialisation
+// as content instead of splitting the row. Inverse of the \| handling in parseCells.
+func escapeCell(value string) string {
+	return strings.ReplaceAll(value, "|", `\|`)
+}
+
+// escapeCells applies escapeCell to every value, returning a new slice.
+func escapeCells(values []string) []string {
+	out := make([]string, len(values))
+	for i, v := range values {
+		out[i] = escapeCell(v)
+	}
+	return out
+}
+
 // WriteTable converts a Table struct back to a markdown table string.
 func WriteTable(t *Table) string {
 	var sb strings.Builder
 
 	// Header row
 	sb.WriteString("| ")
-	sb.WriteString(strings.Join(t.Headers, " | "))
+	sb.WriteString(strings.Join(escapeCells(t.Headers), " | "))
 	sb.WriteString(" |")
 	sb.WriteString("\n")
 
@@ -191,7 +209,7 @@ func WriteTable(t *Table) string {
 		sb.WriteString("| ")
 		vals := make([]string, len(t.Headers))
 		for i, h := range t.Headers {
-			vals[i] = row[h]
+			vals[i] = escapeCell(row[h])
 		}
 		sb.WriteString(strings.Join(vals, " | "))
 		sb.WriteString(" |")

--- a/cli/internal/markdown/markdown_test.go
+++ b/cli/internal/markdown/markdown_test.go
@@ -201,7 +201,6 @@ func TestParseTable_EscapedPipes(t *testing.T) {
 	if len(table.Rows) != 2 {
 		t.Fatalf("row count = %d, want 2", len(table.Rows))
 	}
-	// GFM: \| is an escape, the cell value holds a literal pipe
 	if table.Rows[0]["Example"] != "a | b" {
 		t.Errorf("escaped pipe row = %q, want %q", table.Rows[0]["Example"], "a | b")
 	}
@@ -390,7 +389,6 @@ func TestParseTable_ColumnCountMismatchNamesRow(t *testing.T) {
 	}
 
 	msg := err.Error()
-	// The message must let a user find the row without hand-diffing
 	for _, want := range []string{"row 2", "5", "4", "| c3-102 | db | foundation | active |"} {
 		if !containsStr(msg, want) {
 			t.Errorf("error %q should mention %q", msg, want)
@@ -490,7 +488,6 @@ func TestWriteTable_EscapesPipesInCells(t *testing.T) {
 
 	result := WriteTable(table)
 
-	// A raw pipe in a cell value would split the row into extra columns
 	if !containsStr(result, `| OR operator | a \| b |`) {
 		t.Errorf("pipe in cell should serialise as \\|, got:\n%s", result)
 	}
@@ -508,7 +505,6 @@ func TestWriteTable_EscapesPipesInHeaders(t *testing.T) {
 		t.Errorf("pipe in header should serialise as \\|, got:\n%s", result)
 	}
 
-	// The escaped header must still round-trip to two columns
 	parsed, err := ParseTable(result)
 	if err != nil {
 		t.Fatal(err)
@@ -591,20 +587,19 @@ func TestTableRoundtrip_PipesInCells(t *testing.T) {
 }
 
 func TestTableRoundtrip_NoEscapesIsByteIdentical(t *testing.T) {
-	// Already in WriteTable's canonical shape, so parse→write must not perturb it
-	original := `| Direction | What | From/To |
+	canonicalWriteTableShape := `| Direction | What | From/To |
 |------|------|------|
 | IN | auth tokens | c3-102 |
 | OUT | sessions | c3-103 |`
 
-	table, err := ParseTable(original)
+	table, err := ParseTable(canonicalWriteTableShape)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	written := WriteTable(table)
-	if written != original {
-		t.Errorf("roundtrip changed a table with no escapes:\ngot:\n%s\nwant:\n%s", written, original)
+	if written != canonicalWriteTableShape {
+		t.Errorf("roundtrip changed a table with no escapes:\ngot:\n%s\nwant:\n%s", written, canonicalWriteTableShape)
 	}
 }
 

--- a/cli/internal/markdown/markdown_test.go
+++ b/cli/internal/markdown/markdown_test.go
@@ -201,9 +201,51 @@ func TestParseTable_EscapedPipes(t *testing.T) {
 	if len(table.Rows) != 2 {
 		t.Fatalf("row count = %d, want 2", len(table.Rows))
 	}
-	// Escaped pipe should be preserved in cell content
-	if table.Rows[0]["Example"] != `a \| b` && table.Rows[0]["Example"] != "a | b" {
-		t.Errorf("escaped pipe row = %q", table.Rows[0]["Example"])
+	// GFM: \| is an escape, the cell value holds a literal pipe
+	if table.Rows[0]["Example"] != "a | b" {
+		t.Errorf("escaped pipe row = %q, want %q", table.Rows[0]["Example"], "a | b")
+	}
+}
+
+func TestParseTable_UnescapesPipesInAllPositions(t *testing.T) {
+	tableStr := `| Pattern | Example |
+|---------|---------|
+| \|leading | trailing\| |
+| \|both\| | a \| b \| c |`
+
+	table, err := ParseTable(tableStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		row  int
+		col  string
+		want string
+	}{
+		{0, "Pattern", "|leading"},
+		{0, "Example", "trailing|"},
+		{1, "Pattern", "|both|"},
+		{1, "Example", "a | b | c"},
+	}
+	for _, c := range cases {
+		if got := table.Rows[c.row][c.col]; got != c.want {
+			t.Errorf("row[%d][%s] = %q, want %q", c.row, c.col, got, c.want)
+		}
+	}
+}
+
+func TestParseCells_UnescapesPipe(t *testing.T) {
+	cells := parseCells(`| a \| b | plain |`)
+
+	if len(cells) != 2 {
+		t.Fatalf("cell count = %d, want 2", len(cells))
+	}
+	if cells[0] != "a | b" {
+		t.Errorf("cells[0] = %q, want %q", cells[0], "a | b")
+	}
+	if cells[1] != "plain" {
+		t.Errorf("cells[1] = %q, want %q", cells[1], "plain")
 	}
 }
 
@@ -336,6 +378,43 @@ func TestParseTable_ColumnCountMismatch(t *testing.T) {
 	}
 }
 
+func TestParseTable_ColumnCountMismatchNamesRow(t *testing.T) {
+	tableStr := `| ID | Name | Category | Status | Goal |
+|----|------|----------|--------|------|
+| c3-101 | auth | foundation | active | Auth |
+| c3-102 | db | foundation | active |`
+
+	_, err := ParseTable(tableStr)
+	if err == nil {
+		t.Fatal("expected error for column count mismatch")
+	}
+
+	msg := err.Error()
+	// The message must let a user find the row without hand-diffing
+	for _, want := range []string{"row 2", "5", "4", "| c3-102 | db | foundation | active |"} {
+		if !containsStr(msg, want) {
+			t.Errorf("error %q should mention %q", msg, want)
+		}
+	}
+	if containsStr(msg, "\n") {
+		t.Errorf("error should be a single line, got %q", msg)
+	}
+}
+
+func TestParseTable_SeparatorErrorNamesRow(t *testing.T) {
+	tableStr := `| A | B |
+| not | a separator |
+| 1 | 2 |`
+
+	_, err := ParseTable(tableStr)
+	if err == nil {
+		t.Fatal("expected error for missing separator row")
+	}
+	if !containsStr(err.Error(), "| not | a separator |") {
+		t.Errorf("error %q should quote the offending row", err.Error())
+	}
+}
+
 // =============================================================================
 // WriteTable: structured data → markdown table string
 // =============================================================================
@@ -401,6 +480,47 @@ func TestWriteTable_PreservesColumnOrder(t *testing.T) {
 	}
 }
 
+func TestWriteTable_EscapesPipesInCells(t *testing.T) {
+	table := &Table{
+		Headers: []string{"Pattern", "Example"},
+		Rows: []map[string]string{
+			{"Pattern": "OR operator", "Example": "a | b"},
+		},
+	}
+
+	result := WriteTable(table)
+
+	// A raw pipe in a cell value would split the row into extra columns
+	if !containsStr(result, `| OR operator | a \| b |`) {
+		t.Errorf("pipe in cell should serialise as \\|, got:\n%s", result)
+	}
+}
+
+func TestWriteTable_EscapesPipesInHeaders(t *testing.T) {
+	table := &Table{
+		Headers: []string{"A | B", "C"},
+		Rows:    []map[string]string{},
+	}
+
+	result := WriteTable(table)
+
+	if !containsStr(result, `| A \| B | C |`) {
+		t.Errorf("pipe in header should serialise as \\|, got:\n%s", result)
+	}
+
+	// The escaped header must still round-trip to two columns
+	parsed, err := ParseTable(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed.Headers) != 2 {
+		t.Fatalf("header count = %d, want 2 (%q)", len(parsed.Headers), parsed.Headers)
+	}
+	if parsed.Headers[0] != "A | B" {
+		t.Errorf("headers[0] = %q, want %q", parsed.Headers[0], "A | B")
+	}
+}
+
 // =============================================================================
 // Roundtrip: ParseTable → WriteTable → ParseTable
 // =============================================================================
@@ -431,6 +551,60 @@ func TestTableRoundtrip(t *testing.T) {
 				t.Errorf("roundtrip row[%d][%s] = %q, want %q", i, k, reparsed.Rows[i][k], v)
 			}
 		}
+	}
+}
+
+func TestTableRoundtrip_PipesInCells(t *testing.T) {
+	original := `| Pattern | Example |
+|---------|---------|
+| OR operator | a \| b |
+| Nested | x \| y \| z |
+| Plain | just text |`
+
+	table, err := ParseTable(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	written := WriteTable(table)
+	reparsed, err := ParseTable(written)
+	if err != nil {
+		t.Fatalf("reparse of written table failed: %v\n%s", err, written)
+	}
+
+	if len(reparsed.Headers) != len(table.Headers) {
+		t.Fatalf("roundtrip header count: %d vs %d", len(reparsed.Headers), len(table.Headers))
+	}
+	if len(reparsed.Rows) != len(table.Rows) {
+		t.Fatalf("roundtrip row count: %d vs %d", len(reparsed.Rows), len(table.Rows))
+	}
+	for i, row := range table.Rows {
+		for k, v := range row {
+			if reparsed.Rows[i][k] != v {
+				t.Errorf("roundtrip row[%d][%s] = %q, want %q", i, k, reparsed.Rows[i][k], v)
+			}
+		}
+	}
+	if table.Rows[0]["Example"] != "a | b" {
+		t.Errorf("parsed cell = %q, want %q", table.Rows[0]["Example"], "a | b")
+	}
+}
+
+func TestTableRoundtrip_NoEscapesIsByteIdentical(t *testing.T) {
+	// Already in WriteTable's canonical shape, so parse→write must not perturb it
+	original := `| Direction | What | From/To |
+|------|------|------|
+| IN | auth tokens | c3-102 |
+| OUT | sessions | c3-103 |`
+
+	table, err := ParseTable(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	written := WriteTable(table)
+	if written != original {
+		t.Errorf("roundtrip changed a table with no escapes:\ngot:\n%s\nwant:\n%s", written, original)
 	}
 }
 

--- a/cli/internal/toon/text_test.go
+++ b/cli/internal/toon/text_test.go
@@ -1,0 +1,187 @@
+package toon
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMarshalObjectText_MultilineBecomesBlock(t *testing.T) {
+	type doc struct {
+		ID   string `json:"id"`
+		Body string `json:"body"`
+		Next string `json:"next"`
+	}
+	v := doc{
+		ID:   "adr-20260724-slash-picker-local-only",
+		Body: "# Heading\n\n| col | col |\n| --- | --- |\n| a   | b   |",
+		Next: "tail",
+	}
+
+	out, err := MarshalObjectText(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, `\n`) {
+		t.Fatalf("text output must not contain literal backslash-n:\n%s", out)
+	}
+	if !strings.Contains(out, "id: adr-20260724-slash-picker-local-only\n") {
+		t.Errorf("single-line values should stay key: value\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "body: |-\n") {
+		t.Errorf("multi-line value should open a block scalar\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "\n  # Heading\n") {
+		t.Errorf("block lines should be indented by two spaces\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "\n  | col | col |\n") {
+		t.Errorf("markdown table rows should survive as real lines\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "\nnext: tail\n") {
+		t.Errorf("field after the block must be unambiguously dedented\ngot:\n%s", out)
+	}
+}
+
+func TestMarshalObjectText_BlankLinesCarryNoIndent(t *testing.T) {
+	type doc struct {
+		Body string `json:"body"`
+	}
+	out, err := MarshalObjectText(doc{Body: "a\n\nb"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "  a\n\n  b\n") {
+		t.Errorf("blank line inside a block must not be padded with spaces\ngot:%q", out)
+	}
+}
+
+func TestMarshalObjectText_ChompingIndicators(t *testing.T) {
+	type doc struct {
+		Body string `json:"body"`
+	}
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"no trailing newline strips", "a\nb", "body: |-\n  a\n  b\n"},
+		{"one trailing newline clips", "a\nb\n", "body: |\n  a\n  b\n"},
+		{"extra trailing newlines kept", "a\nb\n\n", "body: |+\n  a\n  b\n\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := MarshalObjectText(doc{Body: tt.body})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if out != tt.want {
+				t.Errorf("want %q\ngot  %q", tt.want, out)
+			}
+		})
+	}
+}
+
+func TestMarshalObjectText_SingleLineMatchesTOON(t *testing.T) {
+	type row struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+		Count int    `json:"count"`
+	}
+	v := row{ID: "c3-1", Title: "API, Gateway", Count: 5}
+
+	text, err := MarshalObjectText(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	toonOut, err := MarshalObject(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text != toonOut {
+		t.Errorf("without multi-line values text mode must match TOON exactly\ntoon: %q\ntext: %q", toonOut, text)
+	}
+}
+
+func TestMarshalObject_MultilineStillEscapedInTOON(t *testing.T) {
+	type doc struct {
+		Body string `json:"body"`
+	}
+	out, err := MarshalObject(doc{Body: "a\nb"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "body: \"a\\nb\"\n" {
+		t.Fatalf("TOON must keep escaping multi-line strings (non-regression), got %q", out)
+	}
+}
+
+func TestMarshalObjectText_NestedStructAndMapIndentBlocks(t *testing.T) {
+	type inner struct {
+		Body string `json:"body"`
+	}
+	type outer struct {
+		Inner inner             `json:"inner"`
+		Meta  map[string]string `json:"meta"`
+	}
+	out, err := MarshalObjectText(outer{
+		Inner: inner{Body: "x\ny"},
+		Meta:  map[string]string{"note": "p\nq"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "inner:\n  body: |-\n    x\n    y\n") {
+		t.Errorf("nested struct block should indent relative to its key\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "meta:\n  note: |-\n    p\n    q\n") {
+		t.Errorf("map value block should indent relative to its key\ngot:\n%s", out)
+	}
+}
+
+func TestMarshalAnyText_SliceElementBlocks(t *testing.T) {
+	out, err := MarshalAnyText([]string{"a\nb", "c"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, `\n`) {
+		t.Fatalf("text list output must not contain literal backslash-n:\n%s", out)
+	}
+	if !strings.Contains(out, "  - |-\n    a\n    b\n") {
+		t.Errorf("multi-line list element should become a block\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "  - c\n") {
+		t.Errorf("single-line list element should stay inline\ngot:\n%s", out)
+	}
+}
+
+func TestMarshalTableText_KeepsGrid(t *testing.T) {
+	type item struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+	}
+	items := []item{{ID: "c3-1", Title: "api"}}
+
+	text, err := MarshalTableText("entities", items, []string{"id", "title"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	toonOut, err := MarshalTable("entities", items, []string{"id", "title"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text != toonOut {
+		t.Errorf("table rows are positional; text mode must keep the TOON grid\ntoon: %q\ntext: %q", toonOut, text)
+	}
+}
+
+func TestMarshalObjectText_CarriageReturnStaysEscaped(t *testing.T) {
+	type doc struct {
+		Body string `json:"body"`
+	}
+	out, err := MarshalObjectText(doc{Body: "a\r\nb"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `\r`) {
+		t.Errorf("CRLF content is not block-safe and must stay quoted\ngot: %q", out)
+	}
+}

--- a/cli/internal/toon/toon.go
+++ b/cli/internal/toon/toon.go
@@ -14,6 +14,16 @@ var reNumber = regexp.MustCompile(`^-?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$`)
 // which implements fmt.Stringer) stay scalar instead of recursing into fields.
 var stringerType = reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
 
+// enc carries the encoder mode so both output shapes share one traversal.
+// multiline renders a multi-line string as a block scalar with real newlines;
+// classic TOON escapes it onto a single physical line.
+type enc struct{ multiline bool }
+
+var (
+	toonEnc = enc{}
+	textEnc = enc{multiline: true}
+)
+
 // NeedsQuoting returns true if the string value needs TOON quoting.
 func NeedsQuoting(s string) bool {
 	if s == "" || s[0] == ' ' || s[len(s)-1] == ' ' {
@@ -68,6 +78,51 @@ func MarshalValue(v any) string {
 	}
 }
 
+// blockIndent is how far a block scalar's lines sit inside their key. A fixed
+// indent is what makes the block self-terminating: the first line that is not
+// indented this far is the next field, not more content.
+const blockIndent = "  "
+
+// isBlockScalar reports whether e would render s as a block scalar rather than a
+// quoted one-liner. CR is deliberately excluded — a bare \r inside a block would
+// be invisible, so CRLF content keeps the escaped form.
+func (e enc) isBlockScalar(s string) bool {
+	return e.multiline && strings.Contains(s, "\n") && !strings.Contains(s, "\r")
+}
+
+// writeBlockScalar renders "<prefix> |<chomp>" followed by the value's real
+// lines, each indented by blockIndent past indent. prefix is "key:" for a field
+// or "-" for a list element.
+func (e enc) writeBlockScalar(b *strings.Builder, indent, prefix, s string) {
+	body, chomp := chompIndicator(s)
+	fmt.Fprintf(b, "%s%s |%s\n", indent, prefix, chomp)
+	inner := indent + blockIndent
+	for _, line := range strings.Split(body, "\n") {
+		if line == "" {
+			// Blank lines stay blank so a block never carries trailing whitespace.
+			b.WriteByte('\n')
+			continue
+		}
+		b.WriteString(inner)
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+}
+
+// chompIndicator splits a value into the lines to emit plus the YAML chomping
+// indicator that makes its trailing newlines exactly recoverable: "-" strip
+// (none), "" clip (exactly one), "+" keep (two or more).
+func chompIndicator(s string) (body, indicator string) {
+	if !strings.HasSuffix(s, "\n") {
+		return s, "-"
+	}
+	body = strings.TrimSuffix(s, "\n")
+	if strings.HasSuffix(body, "\n") {
+		return body, "+"
+	}
+	return body, ""
+}
+
 func quote(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `"`, `\"`)
@@ -80,6 +135,17 @@ func quote(s string) string {
 // MarshalTable serializes a slice of structs as a TOON tabular array.
 // fields specifies which struct fields to include (by json tag name).
 func MarshalTable(label string, items any, fields []string) (string, error) {
+	return toonEnc.table(label, items, fields)
+}
+
+// MarshalTableText serializes a tabular array for --format text. Rows are
+// positional and comma-delimited, so a block scalar has nowhere to live: cells
+// keep the escaped TOON form and the grid is byte-identical to MarshalTable.
+func MarshalTableText(label string, items any, fields []string) (string, error) {
+	return toonEnc.table(label, items, fields)
+}
+
+func (e enc) table(label string, items any, fields []string) (string, error) {
 	rv := reflect.ValueOf(items)
 	if rv.Kind() != reflect.Slice {
 		return "", fmt.Errorf("toon: items must be a slice, got %s", rv.Kind())
@@ -109,7 +175,7 @@ func MarshalTable(label string, items any, fields []string) (string, error) {
 				continue
 			}
 			fv := elem.Field(fi)
-			b.WriteString(marshalFieldValue(fv))
+			b.WriteString(toonEnc.fieldValue(fv))
 		}
 		b.WriteByte('\n')
 	}
@@ -118,7 +184,13 @@ func MarshalTable(label string, items any, fields []string) (string, error) {
 }
 
 // MarshalObject serializes a struct or map as TOON key:value pairs.
-func MarshalObject(v any) (string, error) {
+func MarshalObject(v any) (string, error) { return toonEnc.object(v) }
+
+// MarshalObjectText is MarshalObject for --format text: identical output except
+// that multi-line string values become block scalars with real newlines.
+func MarshalObjectText(v any) (string, error) { return textEnc.object(v) }
+
+func (e enc) object(v any) (string, error) {
 	rv := reflect.ValueOf(v)
 	if rv.Kind() == reflect.Ptr {
 		if rv.IsNil() {
@@ -129,16 +201,22 @@ func MarshalObject(v any) (string, error) {
 
 	switch rv.Kind() {
 	case reflect.Struct:
-		return marshalStruct(rv)
+		return e.structWithIndent(rv, "")
 	case reflect.Map:
-		return marshalMap(rv, "")
+		return e.mapValue(rv, "")
 	default:
 		return "", fmt.Errorf("toon: MarshalObject requires struct or map, got %s", rv.Kind())
 	}
 }
 
 // MarshalAny serializes common command output shapes as TOON.
-func MarshalAny(v any) (string, error) {
+func MarshalAny(v any) (string, error) { return toonEnc.any(v) }
+
+// MarshalAnyText is MarshalAny for --format text: multi-line string values
+// become block scalars with real newlines.
+func MarshalAnyText(v any) (string, error) { return textEnc.any(v) }
+
+func (e enc) any(v any) (string, error) {
 	rv := reflect.ValueOf(v)
 	if !rv.IsValid() {
 		return "null\n", nil
@@ -152,11 +230,11 @@ func MarshalAny(v any) (string, error) {
 
 	switch rv.Kind() {
 	case reflect.Struct, reflect.Map:
-		return MarshalObject(v)
+		return e.object(v)
 	case reflect.Slice, reflect.Array:
 		var b strings.Builder
 		fmt.Fprintf(&b, "items[%d]:\n", rv.Len())
-		out, err := marshalSliceElements(rv, "  ")
+		out, err := e.sliceElements(rv, "  ")
 		if err != nil {
 			return "", err
 		}
@@ -167,11 +245,7 @@ func MarshalAny(v any) (string, error) {
 	}
 }
 
-func marshalStruct(rv reflect.Value) (string, error) {
-	return marshalStructWithIndent(rv, "")
-}
-
-func marshalStructWithIndent(rv reflect.Value, indent string) (string, error) {
+func (e enc) structWithIndent(rv reflect.Value, indent string) (string, error) {
 	var b strings.Builder
 	rt := rv.Type()
 	for i := 0; i < rt.NumField(); i++ {
@@ -198,7 +272,7 @@ func marshalStructWithIndent(rv reflect.Value, indent string) (string, error) {
 		// Handle map fields — render as nested
 		if fv.Kind() == reflect.Map {
 			fmt.Fprintf(&b, "%s%s:\n", indent, name)
-			nested, err := marshalMap(fv, indent+"  ")
+			nested, err := e.mapValue(fv, indent+"  ")
 			if err != nil {
 				return "", err
 			}
@@ -211,7 +285,7 @@ func marshalStructWithIndent(rv reflect.Value, indent string) (string, error) {
 		// to the flat comma-joined form below.
 		if fv.Kind() == reflect.Slice && isStructLikeSlice(fv.Type()) {
 			fmt.Fprintf(&b, "%s%s[%d]:\n", indent, name, fv.Len())
-			nested, err := marshalSliceElements(fv, indent+"  ")
+			nested, err := e.sliceElements(fv, indent+"  ")
 			if err != nil {
 				return "", err
 			}
@@ -236,7 +310,7 @@ func marshalStructWithIndent(rv reflect.Value, indent string) (string, error) {
 		// Structs that render themselves (Stringer, e.g. time.Time) stay scalar.
 		if fv.Kind() == reflect.Struct && !fv.Type().Implements(stringerType) {
 			fmt.Fprintf(&b, "%s%s:\n", indent, name)
-			nested, err := marshalStructWithIndent(fv, indent+"  ")
+			nested, err := e.structWithIndent(fv, indent+"  ")
 			if err != nil {
 				return "", err
 			}
@@ -244,12 +318,17 @@ func marshalStructWithIndent(rv reflect.Value, indent string) (string, error) {
 			continue
 		}
 
-		fmt.Fprintf(&b, "%s%s: %s\n", indent, name, marshalFieldValue(fv))
+		if s, ok := e.blockString(fv); ok {
+			e.writeBlockScalar(&b, indent, name+":", s)
+			continue
+		}
+
+		fmt.Fprintf(&b, "%s%s: %s\n", indent, name, e.fieldValue(fv))
 	}
 	return b.String(), nil
 }
 
-func marshalMap(rv reflect.Value, indent string) (string, error) {
+func (e enc) mapValue(rv reflect.Value, indent string) (string, error) {
 	var b strings.Builder
 	keys := rv.MapKeys()
 	// Sort string keys for deterministic output
@@ -258,7 +337,11 @@ func marshalMap(rv reflect.Value, indent string) (string, error) {
 	})
 	for _, k := range keys {
 		v := rv.MapIndex(k)
-		fmt.Fprintf(&b, "%s%s: %s\n", indent, k.String(), marshalFieldValue(v))
+		if s, ok := e.blockString(v); ok {
+			e.writeBlockScalar(&b, indent, k.String()+":", s)
+			continue
+		}
+		fmt.Fprintf(&b, "%s%s: %s\n", indent, k.String(), e.fieldValue(v))
 	}
 	return b.String(), nil
 }
@@ -280,9 +363,29 @@ func isStructLikeSlice(t reflect.Type) bool {
 	return et.Kind() == reflect.Struct || et.Kind() == reflect.Map
 }
 
-// marshalSliceElements renders each element of a struct/map slice as an indented
+// blockString unwraps a value to a plain string and reports whether this
+// encoder should emit it as a block scalar instead of an inline key: value.
+// Stringer-backed values (time.Time and friends) keep their scalar rendering.
+func (e enc) blockString(v reflect.Value) (string, bool) {
+	if !e.multiline {
+		return "", false
+	}
+	for v.Kind() == reflect.Interface || v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return "", false
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.String || v.Type() != reflect.TypeOf("") {
+		return "", false
+	}
+	s := v.String()
+	return s, e.isBlockScalar(s)
+}
+
+// sliceElements renders each element of a struct/map slice as an indented
 // "-" block. Shared by MarshalAny (top-level slices) and nested struct fields.
-func marshalSliceElements(rv reflect.Value, indent string) (string, error) {
+func (e enc) sliceElements(rv reflect.Value, indent string) (string, error) {
 	var b strings.Builder
 	for i := 0; i < rv.Len(); i++ {
 		elem := rv.Index(i)
@@ -299,26 +402,30 @@ func marshalSliceElements(rv reflect.Value, indent string) (string, error) {
 		switch elem.Kind() {
 		case reflect.Struct:
 			fmt.Fprintf(&b, "%s-\n", indent)
-			out, err := marshalStructWithIndent(elem, indent+"  ")
+			out, err := e.structWithIndent(elem, indent+"  ")
 			if err != nil {
 				return "", err
 			}
 			b.WriteString(out)
 		case reflect.Map:
 			fmt.Fprintf(&b, "%s-\n", indent)
-			out, err := marshalMap(elem, indent+"  ")
+			out, err := e.mapValue(elem, indent+"  ")
 			if err != nil {
 				return "", err
 			}
 			b.WriteString(out)
 		default:
-			fmt.Fprintf(&b, "%s- %s\n", indent, marshalFieldValue(elem))
+			if s, ok := e.blockString(elem); ok {
+				e.writeBlockScalar(&b, indent, "-", s)
+				continue
+			}
+			fmt.Fprintf(&b, "%s- %s\n", indent, e.fieldValue(elem))
 		}
 	}
 	return b.String(), nil
 }
 
-func marshalFieldValue(fv reflect.Value) string {
+func (e enc) fieldValue(fv reflect.Value) string {
 	if fv.Kind() == reflect.Interface {
 		if fv.IsNil() {
 			return "null"
@@ -360,14 +467,14 @@ func marshalFieldValue(fv reflect.Value) string {
 		if fv.IsNil() {
 			return "null"
 		}
-		return marshalFieldValue(fv.Elem())
+		return e.fieldValue(fv.Elem())
 	case reflect.Slice:
 		if fv.IsNil() || fv.Len() == 0 {
 			return ""
 		}
 		var parts []string
 		for i := 0; i < fv.Len(); i++ {
-			parts = append(parts, marshalFieldValue(fv.Index(i)))
+			parts = append(parts, e.fieldValue(fv.Index(i)))
 		}
 		return strings.Join(parts, ",")
 	default:

--- a/cli/internal/toon/toon.go
+++ b/cli/internal/toon/toon.go
@@ -14,14 +14,11 @@ var reNumber = regexp.MustCompile(`^-?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$`)
 // which implements fmt.Stringer) stay scalar instead of recursing into fields.
 var stringerType = reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
 
-// enc carries the encoder mode so both output shapes share one traversal.
-// multiline renders a multi-line string as a block scalar with real newlines;
-// classic TOON escapes it onto a single physical line.
-type enc struct{ multiline bool }
+type enc struct{ multilineAsBlockScalar bool }
 
 var (
-	toonEnc = enc{}
-	textEnc = enc{multiline: true}
+	toonEnc = enc{multilineAsBlockScalar: false}
+	textEnc = enc{multilineAsBlockScalar: true}
 )
 
 // NeedsQuoting returns true if the string value needs TOON quoting.
@@ -78,49 +75,43 @@ func MarshalValue(v any) string {
 	}
 }
 
-// blockIndent is how far a block scalar's lines sit inside their key. A fixed
-// indent is what makes the block self-terminating: the first line that is not
-// indented this far is the next field, not more content.
-const blockIndent = "  "
+const (
+	blockIndent          = "  "
+	invisibleInsideBlock = "\r"
 
-// isBlockScalar reports whether e would render s as a block scalar rather than a
-// quoted one-liner. CR is deliberately excluded — a bare \r inside a block would
-// be invisible, so CRLF content keeps the escaped form.
+	chompStrip = "-"
+	chompClip  = ""
+	chompKeep  = "+"
+)
+
 func (e enc) isBlockScalar(s string) bool {
-	return e.multiline && strings.Contains(s, "\n") && !strings.Contains(s, "\r")
+	return e.multilineAsBlockScalar &&
+		strings.Contains(s, "\n") &&
+		!strings.Contains(s, invisibleInsideBlock)
 }
 
-// writeBlockScalar renders "<prefix> |<chomp>" followed by the value's real
-// lines, each indented by blockIndent past indent. prefix is "key:" for a field
-// or "-" for a list element.
 func (e enc) writeBlockScalar(b *strings.Builder, indent, prefix, s string) {
 	body, chomp := chompIndicator(s)
 	fmt.Fprintf(b, "%s%s |%s\n", indent, prefix, chomp)
 	inner := indent + blockIndent
 	for _, line := range strings.Split(body, "\n") {
-		if line == "" {
-			// Blank lines stay blank so a block never carries trailing whitespace.
-			b.WriteByte('\n')
-			continue
+		if line != "" {
+			b.WriteString(inner)
+			b.WriteString(line)
 		}
-		b.WriteString(inner)
-		b.WriteString(line)
 		b.WriteByte('\n')
 	}
 }
 
-// chompIndicator splits a value into the lines to emit plus the YAML chomping
-// indicator that makes its trailing newlines exactly recoverable: "-" strip
-// (none), "" clip (exactly one), "+" keep (two or more).
 func chompIndicator(s string) (body, indicator string) {
 	if !strings.HasSuffix(s, "\n") {
-		return s, "-"
+		return s, chompStrip
 	}
 	body = strings.TrimSuffix(s, "\n")
 	if strings.HasSuffix(body, "\n") {
-		return body, "+"
+		return body, chompKeep
 	}
-	return body, ""
+	return body, chompClip
 }
 
 func quote(s string) string {
@@ -135,17 +126,15 @@ func quote(s string) string {
 // MarshalTable serializes a slice of structs as a TOON tabular array.
 // fields specifies which struct fields to include (by json tag name).
 func MarshalTable(label string, items any, fields []string) (string, error) {
-	return toonEnc.table(label, items, fields)
+	return marshalGrid(label, items, fields)
 }
 
-// MarshalTableText serializes a tabular array for --format text. Rows are
-// positional and comma-delimited, so a block scalar has nowhere to live: cells
-// keep the escaped TOON form and the grid is byte-identical to MarshalTable.
 func MarshalTableText(label string, items any, fields []string) (string, error) {
-	return toonEnc.table(label, items, fields)
+	// Grid cells are comma-delimited, so text mode has no block scalar to render.
+	return marshalGrid(label, items, fields)
 }
 
-func (e enc) table(label string, items any, fields []string) (string, error) {
+func marshalGrid(label string, items any, fields []string) (string, error) {
 	rv := reflect.ValueOf(items)
 	if rv.Kind() != reflect.Slice {
 		return "", fmt.Errorf("toon: items must be a slice, got %s", rv.Kind())
@@ -186,8 +175,6 @@ func (e enc) table(label string, items any, fields []string) (string, error) {
 // MarshalObject serializes a struct or map as TOON key:value pairs.
 func MarshalObject(v any) (string, error) { return toonEnc.object(v) }
 
-// MarshalObjectText is MarshalObject for --format text: identical output except
-// that multi-line string values become block scalars with real newlines.
 func MarshalObjectText(v any) (string, error) { return textEnc.object(v) }
 
 func (e enc) object(v any) (string, error) {
@@ -212,8 +199,6 @@ func (e enc) object(v any) (string, error) {
 // MarshalAny serializes common command output shapes as TOON.
 func MarshalAny(v any) (string, error) { return toonEnc.any(v) }
 
-// MarshalAnyText is MarshalAny for --format text: multi-line string values
-// become block scalars with real newlines.
 func MarshalAnyText(v any) (string, error) { return textEnc.any(v) }
 
 func (e enc) any(v any) (string, error) {
@@ -363,11 +348,8 @@ func isStructLikeSlice(t reflect.Type) bool {
 	return et.Kind() == reflect.Struct || et.Kind() == reflect.Map
 }
 
-// blockString unwraps a value to a plain string and reports whether this
-// encoder should emit it as a block scalar instead of an inline key: value.
-// Stringer-backed values (time.Time and friends) keep their scalar rendering.
 func (e enc) blockString(v reflect.Value) (string, bool) {
-	if !e.multiline {
+	if !e.multilineAsBlockScalar {
 		return "", false
 	}
 	for v.Kind() == reflect.Interface || v.Kind() == reflect.Ptr {
@@ -376,11 +358,17 @@ func (e enc) blockString(v reflect.Value) (string, bool) {
 		}
 		v = v.Elem()
 	}
-	if v.Kind() != reflect.String || v.Type() != reflect.TypeOf("") {
+	if !isPlainString(v) {
 		return "", false
 	}
 	s := v.String()
 	return s, e.isBlockScalar(s)
+}
+
+var plainStringType = reflect.TypeOf("")
+
+func isPlainString(v reflect.Value) bool {
+	return v.Kind() == reflect.String && v.Type() == plainStringType
 }
 
 // sliceElements renders each element of a struct/map slice as an indented

--- a/cli/main.go
+++ b/cli/main.go
@@ -138,16 +138,13 @@ func runWithIO(argv []string, stdin io.Reader, stdinTerminal bool, w io.Writer, 
 	// Mutations bypass preverify (ADR mutation-preverify-repair-bypass): the
 	// mutation itself may be the fix.
 	if hasCanonical {
+		cacheMissingButDerivable := !hasDB
 		switch {
 		case mutates:
 			if err := cmd.EnsureLocalCache(c3Dir, opts.IncludeADR, opts.Only, io.Discard); err != nil {
 				return fmt.Errorf("error: refresh cache before %q: %w", opts.Command, err)
 			}
-		case !hasDB:
-			// A missing cache in an already-onboarded tree — a fresh `git worktree`
-			// is the common case — is not a decision for the user: the cache is
-			// disposable and derivable from canonical .c3/. Rebuild instead of
-			// failing on the session's very first command.
+		case cacheMissingButDerivable:
 			if err := cmd.EnsureLocalCache(c3Dir, opts.IncludeADR, opts.Only, io.Discard); err != nil {
 				return fmt.Errorf("error: rebuild local C3 cache from canonical .c3/: %w", err)
 			}

--- a/cli/main.go
+++ b/cli/main.go
@@ -36,6 +36,10 @@ func run(argv []string, w io.Writer) error {
 func runWithIO(argv []string, stdin io.Reader, stdinTerminal bool, w io.Writer, stderr io.Writer, coordinate bool) error {
 	opts := cmd.ParseArgs(argv)
 
+	if err := cmd.ValidateFormatFlag(opts.Format); err != nil {
+		return err
+	}
+
 	if opts.File != "" && commandAcceptsFile(opts.Command) {
 		f, err := os.Open(opts.File)
 		if err != nil {
@@ -134,16 +138,25 @@ func runWithIO(argv []string, stdin io.Reader, stdinTerminal bool, w io.Writer, 
 	// Mutations bypass preverify (ADR mutation-preverify-repair-bypass): the
 	// mutation itself may be the fix.
 	if hasCanonical {
-		if mutates {
+		switch {
+		case mutates:
 			if err := cmd.EnsureLocalCache(c3Dir, opts.IncludeADR, opts.Only, io.Discard); err != nil {
 				return fmt.Errorf("error: refresh cache before %q: %w", opts.Command, err)
+			}
+		case !hasDB:
+			// A missing cache in an already-onboarded tree — a fresh `git worktree`
+			// is the common case — is not a decision for the user: the cache is
+			// disposable and derivable from canonical .c3/. Rebuild instead of
+			// failing on the session's very first command.
+			if err := cmd.EnsureLocalCache(c3Dir, opts.IncludeADR, opts.Only, io.Discard); err != nil {
+				return fmt.Errorf("error: rebuild local C3 cache from canonical .c3/: %w", err)
 			}
 		}
 		hasDB = fileExists(dbPath)
 	}
 
 	if !hasDB {
-		return fmt.Errorf("error: local C3 cache unavailable at %s\nhint: run 'c3x check' to rebuild from canonical .c3/, or 'c3x init' if this project is not onboarded", dbPath)
+		return fmt.Errorf("error: local C3 cache unavailable at %s\nhint: run 'c3x repair' to rebuild from canonical .c3/, or 'c3x init' if this project is not onboarded", dbPath)
 	}
 
 	var rollback *mutationSnapshot

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -563,10 +563,7 @@ func TestRun_RepairBypassesBrokenSealPreverifyWithoutCache(t *testing.T) {
 	}
 }
 
-// A fresh `git worktree` carries the canonical .c3/ tree but no c3.db — the cache
-// is gitignored and derivable by definition. A read command must rebuild it
-// instead of failing, so the first c3x call in a new worktree just works.
-func TestBDD_FreshWorktreeReadRebuildsMissingCache(t *testing.T) {
+func TestBDD_FreshWorktreeReadRebuildsMissingCacheFromCanonicalDocs(t *testing.T) {
 	c3Dir := setupRichC3DB(t)
 	seedCanonicalReadme(t, c3Dir)
 	if err := os.Remove(filepath.Join(c3Dir, "c3.db")); err != nil {
@@ -593,9 +590,7 @@ func TestBDD_FreshWorktreeReadRebuildsMissingCache(t *testing.T) {
 	}
 }
 
-// When there is nothing to rebuild from, the failure must route to the command
-// that rebuilds a cache — `repair` — not to the validator (`check`).
-func TestRun_CacheUnavailableHintNamesRepair(t *testing.T) {
+func TestRun_CacheUnavailableHintNamesRepairNotCheck(t *testing.T) {
 	c3Dir := filepath.Join(t.TempDir(), ".c3")
 	if err := os.MkdirAll(c3Dir, 0o755); err != nil {
 		t.Fatal(err)

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -563,6 +563,56 @@ func TestRun_RepairBypassesBrokenSealPreverifyWithoutCache(t *testing.T) {
 	}
 }
 
+// A fresh `git worktree` carries the canonical .c3/ tree but no c3.db — the cache
+// is gitignored and derivable by definition. A read command must rebuild it
+// instead of failing, so the first c3x call in a new worktree just works.
+func TestBDD_FreshWorktreeReadRebuildsMissingCache(t *testing.T) {
+	c3Dir := setupRichC3DB(t)
+	seedCanonicalReadme(t, c3Dir)
+	if err := os.Remove(filepath.Join(c3Dir, "c3.db")); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := runWithIO(
+		[]string{"--c3-dir", c3Dir, "list"},
+		strings.NewReader(""),
+		true,
+		&stdout,
+		&stderr,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("read in a fresh worktree must rebuild the cache, got: %v\nstderr:\n%s", err, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(c3Dir, "c3.db")); err != nil {
+		t.Fatalf("cache was not rebuilt: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "c3-101") {
+		t.Fatalf("rebuilt cache should answer the read, stdout:\n%s", stdout.String())
+	}
+}
+
+// When there is nothing to rebuild from, the failure must route to the command
+// that rebuilds a cache — `repair` — not to the validator (`check`).
+func TestRun_CacheUnavailableHintNamesRepair(t *testing.T) {
+	c3Dir := filepath.Join(t.TempDir(), ".c3")
+	if err := os.MkdirAll(c3Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := run([]string{"--c3-dir", c3Dir, "list"}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected a cache-unavailable error")
+	}
+	if !strings.Contains(err.Error(), "c3x repair") {
+		t.Fatalf("cache-unavailable hint must name 'c3x repair', got: %v", err)
+	}
+	if strings.Contains(err.Error(), "'c3x check'") {
+		t.Fatalf("cache-unavailable hint must not send the user to the validator, got: %v", err)
+	}
+}
+
 func TestRun_AgentModeRepairOmitsProse(t *testing.T) {
 	t.Setenv("C3X_MODE", "agent")
 	c3Dir := setupRichC3DB(t)

--- a/skills/c3/SKILL.md
+++ b/skills/c3/SKILL.md
@@ -82,10 +82,10 @@ The packaged CLI is the catalog — invoke the local wrapper with `<cmd> --help`
 | `list` | Topology with counts + coverage (`--flat`, `--compact`) |
 | `check` | Validate facts against their canvas + consistency (`--fix`, `--only`, `--include-adr`). Fact-vs-code conformance is **not** here — run the wrapper's separate, off-switch `eval` operation |
 | `eval` | Check a frozen fact's claim against the uncontrolled external it governs (the `code:` binding in `.c3/eval/<fact>.yaml`). A one-off CI-cadence verdict, **never a gate** (`references/eval.md`) |
-| `repair` | Rebuild the disposable cache from canonical `.c3/` and reseal (after a branch switch / selective merge) |
+| `repair` | Rebuild the disposable cache from canonical `.c3/` and reseal (after a branch switch / selective merge). A *missing* cache — a fresh `git worktree` — needs no command: reads rebuild it on demand |
 | `search <query>` | Concept → entities by semantic + keyword + graph signal, with route clues when available |
 | `lookup <file-or-glob>` | File/glob → component(s) + refs |
-| `read <id>` | Entity content (`--full`; `--section <name> --cite` emits the patch base anchor) |
+| `read <id>` | Entity content (`--full`; `--cite` emits both the entity anchor and per-node anchors, `--section <name> --cite` narrows to one section). The `sha256` is the anchor — `#nNODE` renumbers on a cache rebuild (`references/change.md` §Cite handles) |
 | `graph <id>` | Relationship graph plus route facets (`facts`, `graph`, `anchors`, `lanes`, `drift`, `hash`); `--depth`, `--direction forward\|reverse`, `--format mermaid`, `--unit <adr-id>` previews staged patches |
 | `add <type> <slug>` | **Create** a fact (body via stdin or `--file`; `--container`, `--feature`). The unguarded create path |
 | `canvas <list\|read\|add\|write>` | Manage canvas definitions (user-owned shape, at `.c3/canvases/`) |

--- a/skills/c3/references/change.md
+++ b/skills/c3/references/change.md
@@ -36,8 +36,26 @@ C3X_MODE=agent bash "<skill-dir>/bin/c3x.sh" change status <adr-id>             
 # 5. Record human judgment, then flip.
 C3X_MODE=agent bash "<skill-dir>/bin/c3x.sh" change accept <adr-id>                # status → accepted (the one stored bit)
 C3X_MODE=agent bash "<skill-dir>/bin/c3x.sh" change apply <adr-id>                 # the switch: drift → canvas → morph → retire, atomic
+
+# 6. Refresh the change-doc's Evidence — apply just rewrote the blocks it cites (§After-cites go
+#    stale on apply). `apply` lists the targets it touched; re-cite each one and write the doc back.
+C3X_MODE=agent bash "<skill-dir>/bin/c3x.sh" read <id> --section <name> --cite     # the post-change handle
+C3X_MODE=agent bash "<skill-dir>/bin/c3x.sh" write <adr-id> < adr-body.md         # paste the refreshed handles
 C3X_MODE=agent bash "<skill-dir>/bin/c3x.sh" check                                 # close; --fix latches accepted → done when After-cites resolve
 ```
+
+## After-cites go stale on apply — that is the proof, not a bug
+
+An `Affected Topology` Evidence cell anchors the block the unit is about to rewrite. `apply`
+rewrites exactly that block, so **every Evidence cite that documented a real change is stale the
+moment the apply succeeds** — only rows for entities the unit did *not* patch survive. This is the
+down-V closing (§What the switch proves): the cite is an **After**-cite, and refreshing it is what
+demonstrates the fact actually landed. The `accepted → done` latch fires only once the refreshed
+cites resolve fresh, so a tool that re-stamped them during `apply` would latch on nothing.
+
+So the staleness is expected and the recovery is step 6, not a repair. `apply` prints the targets it
+touched precisely so you do not have to reconstruct them; `check --include-adr --only <adr-id>`
+then names any cell still unrefreshed, and says whether the hash or the snippet is what mismatched.
 
 The **file-context gate is MANDATORY before authoring any fact-edit patch**: run the wrapper's `lookup <file>` operation, load every `rule-*` and the parent chain, honor the refs/rules. `apply` will not launder a non-compliant edit — the body you author must already comply. Each parallel subagent runs this gate on its own files.
 
@@ -71,7 +89,9 @@ result: sha256:<hash>      # optional landing check (block) — see below
 
 **Body-owned edges.** When `schema <type>` marks a table column with `edge: uses`, that body column is the canonical edge source. A `frontmatter` patch carrying `uses:` is rejected before any write; edit or insert the cited table row instead. The rejection names the owning section and column and prints the exact `read --section ... --cite` repair command. Frontmatter `uses:` remains legal for legacy or custom canvases without a body-owned `uses` column.
 
-**Cite handles** (from `C3X_MODE=agent bash "<skill-dir>/bin/c3x.sh" read <id> --cite`): a **block** anchor `entity#nNODE@vVER:sha256:HASH` pins one node by its hash (`block` scope); the **entity** anchor `entity@vVER:sha256:ROOTMERKLE` pins the whole fact (`insert` / `frontmatter` / `retire`).
+**Cite handles** (from `C3X_MODE=agent bash "<skill-dir>/bin/c3x.sh" read <id> --cite`, which emits both forms; `--section <name> --cite` narrows to that section's nodes): a **block** anchor `entity#nNODE@vVER:sha256:HASH` pins one node by its hash (`block` scope); the **entity** anchor `entity@vVER:sha256:ROOTMERKLE` pins the whole fact (`insert` / `frontmatter` / `retire`).
+
+**The `sha256` is the anchor; `#nNODE` is only a lookup hint.** Node ids are a local cache counter, so a `repair` / re-import renumbers them — the same content legitimately reads as `#n6509` in one worktree and `#n6577` in another. Resolution falls back to matching the hash across the fact's nodes, so a handle recorded in a durable document keeps working across rebuilds and across collaborators. Never compare two handles by their `#nNODE`; compare the hash. The trailing `"snippet"` is likewise optional evidence for humans, not part of the anchor — drop it when quoting it would be awkward (a table row's text contains `|`).
 
 **Membership rows are NOT yours — set `parent:`, the row appears** (SKILL.md §Membership). A parent's `Components`/`Containers` table is synthesized from children's `parent:` links on every parentage path. Never insert, re-cite, or hand-remove a membership row; a reparent/retire heals the parent it leaves. Author a parent patch only when its **Responsibilities** or a member's **Goal Contribution** *framing* changes — that is a second patch, authored together (the parent-delta decision: record `Parent Delta: updated` and name the patch, or `Parent Delta: none` with evidence).
 


### PR DESCRIPTION
Closes #94, #111, #112, #113, #114, #115, #116.

Seven issues, one theme: the tool validated late, reported the wrong cause, and silently rewrote what the author wrote. Each fix below was reproduced against v11.6.3 before being written, TDD.

## Data loss

**#111 — table cells lost all inline markup.** `content.extractTableRow` read cells through goldmark's `Text()`, which returns inline *text*: backticks, `*emphasis*` and `[links](url)` were deleted from every table cell on every write, and `WriteEntity` re-rendered the document from those nodes, persisting the loss. Cells now come from their raw source segment. Paragraphs were never affected — only cells.

```
before:  got `chat.send` and *emph*   ->  stored: got chat.send and emph
after:   got `chat.send` and *emph*   ->  stored: got `chat.send` and *emph*
```

**#112 — `\|` never round-tripped.** `parseCells` recognised the escape but re-emitted the backslash, so a cell authored `a \| b` had the value `a \| b` while the node text was `a | b`. A cite snippet taken from a table row — most of the corpus — was therefore unwritable in either encoding: raw pipes broke the table, escaped pipes read as stale. Escapes now unescape on parse and `WriteTable` re-escapes on write, symmetrically.

## Wrong causes

**#111/#112/#114 — "stale node hash or snippet" was affirmatively false.** It reported a stale hash even when the hash was current and only the snippet differed, and its hint sent you to refresh a handle that came back byte-identical. `evidenceNodeMatches` now returns *which* half failed; a snippet mismatch prints cited-vs-actual and notes the snippet is optional (the sha256 is the anchor).

**#114 — hints pointed at the command whose output they had just rejected.** Bare `read <id> --cite` emits the entity-root handle; Evidence needs a node handle. Every such hint now names `--section <name> --cite`, and bare `--cite` additionally lists per-node handles labelled by what each anchors.

**#94 — a decorated cell was interpolated whole as an id.** When the first token of `c3-3 shared (prompt.ts)` resolves, the rejection now says the cell must carry only the bare id. The panic this issue originally reported was already fixed at HEAD; a regression test with `recover()` pins it.

## Round-trips

**#116.1 — one failure class per submission.** Row validation bailed at the first finding, so one ADR took four submissions to surface four independently-detectable classes. Findings are now collected in one pass. The sole remaining skip is the genuine dependency — Evidence cannot be checked *against* a target that does not resolve — and the cell-shape checks still run there.

**#116.2 — table-shape errors didn't name the row.** The parser knew the row number and expected-vs-actual counts; all four validators dropped it. Now: `invalid required table: Governance — column count mismatch in data row 1: header has 5 columns, row has 4: | ref-jwt | ref | ... |`.

**#115 — fresh worktree.** Canonical `.c3/` present, no `c3.db`, and the hint offered `check` and `init` but never `repair`. Reads now rebuild the cache on demand (it is disposable and derivable — nothing for the user to decide); the remaining failure names `repair`.

**#116.3 — `--format text`.** Agent mode flattened bodies onto one line with literal `\n`, and the obvious shell fix (`tr '\\n' '\n'`) silently eats every literal `n`. Text format emits YAML block scalars with real newlines and exact chomping. TOON stays the agent-mode default; this is opt-in and single-line values are byte-identical.

## Design, documented rather than changed

**#113 — apply invalidates the ADR's own Evidence.** That is the proof, not a bug: those are *After*-cites, and the `accepted → done` latch fires only once they are refreshed and resolve fresh — which is what demonstrates the change landed. Auto-refreshing inside `apply`, as the issue suggests, would make the latch prove nothing. Instead `change apply` now prints the targets it touched plus the refresh step, and `references/change.md` carries the refresh as an explicit stage instead of stopping at `check`.

**#116.4 — node ids.** `#nNODE` is a lookup hint; the sha256 is the anchor. Ids renumber on a cache rebuild and resolution falls back to matching the hash, so handles survive rebuilds and differ harmlessly between collaborators. Now documented.

## Verification

- Full Go suite green (`./cmd/ ./internal/... .`), `go vet` clean, `gofmt` clean on every touched file.
- `c3x check` — 41 docs clear, canonical in sync.
- `c3x eval` — 26/26 hold, 0 drift.
- `tools/structural-search-eval-v2` still fails its pre-existing Linux-only `unix.Openat2` build on darwin; untouched.

## Migration note for #111

The extractor change moves a node's hash **only** for table cells whose markdown still carries inline markup on disk. Documents written by an earlier version already had it stripped, so re-parsing is idempotent — verified by rebuilding this repo's `.c3/` from scratch and diffing: byte-identical, zero seal churn. A repo with hand-authored table cells containing backticks or emphasis should run `c3x repair` once and re-cite any Evidence handle the rebuild reports stale.

## Not included

No version bump — `VERSION` and the five other surfaces stay at 11.6.3 so you can cut the release. The CHANGELOG entry proposes `11.7.0` (new flag + behaviour changes, backward compatible); retitle as you prefer.

## Found but not fixed (separate issue material)

`content.WriteEntity` calls `RenderMarkdown(tree.Nodes)` before node parents are assigned (`bridge.go:17`), so the `versions.content` snapshot is structurally corrupt — tables lose their pipes and separator row. Consumed only by `cmd/conflict.go:23` (the rebase BASE view). Real, unrelated to these seven; flagging rather than widening this PR.